### PR TITLE
absolutize redirect urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,6 +71,7 @@ class ApplicationController < ActionController::Base
   # ----------( rendering methods ) -------------
 
   def wagn_redirect url
+    url = wagn_url url #make sure we have absolute url
     if ajax?
       render :text => url, :status => 303
     else

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -228,7 +228,7 @@ class CardController < ApplicationController
       end
 
     case
-    when  redirect        ; wagn_redirect ( Card===target ? url_for_page(target.cardname, new_params) : target )
+    when  redirect        ; wagn_redirect ( Card===target ? path_for_page( target.cardname, new_params ) : target )
     when  String===target ; render :text => target
     else
       @card = target

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -23,8 +23,8 @@ module LocationHelper
   def save_location
     return if ajax? || !html? || !@card.known?
 
-    discard_locations_for(@card)
-    @previous_location = wagn_path(@card)
+    discard_locations_for @card
+    @previous_location = wagn_path @card
     location_history.push @previous_location
   end
 
@@ -50,7 +50,7 @@ module LocationHelper
 
 
   # FIXME: missing test
-  def url_for_page( title, opts={} )
+  def path_for_page( title, opts={} )
     format = (opts[:format] ? ".#{opts.delete(:format)}"  : "")
     vars = ''
     if !opts.empty?
@@ -61,13 +61,13 @@ module LocationHelper
     wagn_path "/#{title.to_name.url_key}#{format}#{vars}"
   end
 
-  def wagn_path( rel ) #should be in cardname?
+  def wagn_path( rel ) #should be in smartname?
     rel_path = Card===rel ? rel.cardname.url_key : rel
     Wagn::Conf[:root_path].to_s + ( rel_path =~ /^\// ? '' : '/' ) + rel_path
   end
 
-  def wagn_url( rel ) #should be in cardname?
-    "#{Wagn::Conf[:base_url]}#{wagn_path(rel)}"
+  def wagn_url rel #should be in smartname?
+    rel =~ /^http\:/ ? rel : "#{Wagn::Conf[:base_url]}#{wagn_path(rel)}"
   end
 
 
@@ -76,7 +76,7 @@ module LocationHelper
   def link_to_page( text, title=nil, options={})
     title ||= text
     url_options = (options[:type]) ? {:type=>options[:type]} : {}
-    url = url_for_page(title, url_options)
+    url = path_for_page(title, url_options)
     link_to text, url, options
   end
 

--- a/lib/wagn/set/self/head_and_foot.rb
+++ b/lib/wagn/set/self/head_and_foot.rb
@@ -24,7 +24,7 @@ module Wagn
         if root.card.type_id == Card::SearchTypeID
           opts = { :format => :rss }
           root.search_params[:vars].each { |key, val| opts["_#{key}"] = val }
-          rss_href = url_for_page root.card.name, opts
+          rss_href = path_for_page root.card.name, opts
           bits << %{<link rel="alternate" type="application/rss+xml" title="RSS" href=#{rss_href} />}
        end
       end

--- a/test/functional/account_request_test.rb
+++ b/test/functional/account_request_test.rb
@@ -26,7 +26,7 @@ class AccountRequestTest < ActionController::TestCase
       :content=>"Let me in!"
     }
     assert_response 302
-    #assert_redirected_to @controller.url_for_page(::Setting.find_by_codename('account_request_landing').card.name)
+    #assert_redirected_to @controller.path_for_page(::Setting.find_by_codename('account_request_landing').card.name)
   end
 
   def test_should_create_account_request

--- a/test/integration/card_action_test.rb
+++ b/test/integration/card_action_test.rb
@@ -97,11 +97,11 @@ class CardActionTest < ActionController::IntegrationTest
       t2 = Card.create! :name => "Testable1+bandana", :content => "world"
     end
 
-    get url_for_page( t1.name )
-    get url_for_page( t2.name )
+    get path_for_page( t1.name )
+    get path_for_page( t2.name )
 
     post 'card/delete/~' + t2.id.to_s
-    assert_redirected_to url_for_page( t1.name )
+    assert_redirected_to path_for_page( t1.name )
     assert_nil Card[ t2.name ]
 
     post 'card/delete/~' + t1.id.to_s


### PR DESCRIPTION
this is to fix brokenness in javascript-based redirects in IE. also makes api a tad more consistent (esp. path vs url)
