### PR TITLE
tweaked renderer error handling

### DIFF
--- a/lib/cardlib/settings.rb
+++ b/lib/cardlib/settings.rb
@@ -75,7 +75,7 @@ module Cardlib::Settings
 
     SETTING_ATTRIBUTES = {
       :perms => [ :create, :read, :update, :delete, :comment ],
-      :look  => [ :default, :content, :layout, :table_of_content ],
+      :look  => [ :default, :content, :layout, :table_of_contents ],
       :com   => [ :add_help, :edit_help, :send, :thanks ],
       :other => [ :autoname, :accountable, :captcha ]
     }

--- a/lib/wagn/renderer.rb
+++ b/lib/wagn/renderer.rb
@@ -182,7 +182,7 @@ module Wagn
       if respond_to? method
         send method, args
       else
-        "<strong>unknown view: <em>#{view}</em></strong>"
+        unknown_view view
       end
     end
 
@@ -203,8 +203,27 @@ module Wagn
       optional_render view, args, default_hidden
     end
 
-    def rendering_error exception, cardname
-      "Error rendering: #{cardname}"
+    def rescue_view e, view
+      controller.send :notify_airbrake, e if Airbrake.configuration.api_key
+      Rails.logger.info "\nError rendering #{error_cardname} / #{view}: #{e.class} : #{e.message}"
+      Rails.logger.debug "  #{e.backtrace*"\n  "}"
+      rendering_error e, view
+    end
+
+    def error_cardname
+      card && card.name.present? ? card.name : 'unknown card'
+    end
+    
+    def unknown_view view
+      "unknown view: #{view}"
+    end
+
+    def unsupported_view view
+      "view (#{view}) not supported for #{error_cardname}"
+    end
+
+    def rendering_error exception, view
+      "Error rendering: #{error_cardname} (#{view} view)"
     end
 
     #

--- a/lib/wagn/renderer/html.rb
+++ b/lib/wagn/renderer/html.rb
@@ -148,8 +148,16 @@ module Wagn
       %{<div class="card-notice"></div>}
     end
 
-    def rendering_error exception, cardname
-      %{<span class="render-error">error rendering #{link_to_page(cardname, nil, :title=>CGI.escapeHTML(exception.message))}</span>}
+    def rendering_error exception, view
+      %{<span class="render-error">error rendering #{link_to_page(error_cardname, nil, :title=>CGI.escapeHTML(exception.message))} (#{view} view)</span>}
+    end
+    
+    def unknown_view view
+      "<strong>unknown view: <em>#{view}</em></strong>"
+    end
+    
+    def unsupported_view view
+      "<strong>view <em>#{view}</em> not supported for <em>#{error_cardname}</em></strong>"
     end
 
     def link_to_view text, view, html_opts={}

--- a/lib/wagn/set/right/rstar.rb
+++ b/lib/wagn/set/right/rstar.rb
@@ -4,7 +4,7 @@ module Wagn
 
     format :html
 
-    define_view :closed_rule, :tags=>:unknown_ok do |args|
+    define_view :closed_rule, :rstar=>true, :tags=>:unknown_ok do |args|
       rule_card = card.new_card? ? find_current_rule_card[0] : card
 
       cells = [
@@ -30,7 +30,7 @@ module Wagn
 
 
 
-    define_view :open_rule, :tags=>:unknown_ok do |args|
+    define_view :open_rule, :rstar=>true, :tags=>:unknown_ok do |args|
       current_rule, prototype = find_current_rule_card
       setting_name = card.cardname.tag
       current_rule ||= Card.new :name=> "*all+#{setting_name}"
@@ -87,7 +87,7 @@ module Wagn
 
     end
 
-    define_view :edit_rule, :tags=>:unknown_ok do |args|
+    define_view :edit_rule, :rstar=>true, :tags=>:unknown_ok do |args|
       edit_mode       = args[:edit_mode]
       setting_name    = args[:setting_name]
       current_set_key = args[:current_set_key] || '*all' # Card[:all].name (should have a constant for this?)


### PR DESCRIPTION
improvements:
-  got html out of errors in non-html renderers (though those errors should probably eventually go to views, too)
-  made it so rescue happens from #_render (not just #render)
-  moved actual rescue handling into new method outside of #_render so (a) it can be customized, and (b) it's not repeated in every single view method def
-  specified :rstar=>true on rstar-specific sets
-  fixed misleading spacing on alias_view
