### PR TITLE
tiny bugfix for edit_type

### DIFF
--- a/lib/wagn/set/all/rich_html.rb
+++ b/lib/wagn/set/all/rich_html.rb
@@ -324,7 +324,7 @@ module Wagn
             #'main-success'=>'REDIRECT: _self', # adding this back in would make main cards redirect on cardtype changes
             %{ 
               #{ hidden_field_tag :view, :edit }
-              #{if card.type_id == Card::CardtypeID and !Card.search(:type_id=>card.card.id).empty? #ENGLISH
+              #{if card.type_id == Card::CardtypeID and !Card.search(:type_id=>card.id).empty? #ENGLISH
                 %{<div>Sorry, you can't make this card anything other than a Cardtype so long as there are <strong>#{ card.name }</strong> cards.</div>}
               else
                 _render_type_editor :variety=>:edit #FIXME dislike this api -ef


### PR DESCRIPTION
smallest pr to date?

(bogus associations recently removed previously allowed this to sneak by)
