### PR TITLE
preserve context names across AJAX requests

### DIFF
--- a/app/assets/javascripts/wagn.js.coffee
+++ b/app/assets/javascripts/wagn.js.coffee
@@ -10,14 +10,14 @@ wagn.prepUrl = (url, slot)->
   main = $('#main').children('.card-slot').attr 'card-name'
   xtra['main'] = main if main?
   if slot
-    home_view = slot.attr 'home_view'
-    item      = slot.attr 'item'
-    title     = slot.children('.card-header').children '.card-title'
-    xtra['home_view'] = home_view if home_view?
-    xtra['item']      = item      if item?
-    xtra['is_main']   = true      if slot.isMain()
-    if title?
-      xtra['name_context'] = $(title[0]).attr 'name_context'
+    home_view    = slot.attr 'home_view'
+    item         = slot.attr 'item'
+    name_context = slot.attr 'name_context'
+#    title     = slot.children('.card-header').children '.card-title'
+    xtra['home_view']    = home_view    if home_view?
+    xtra['item']         = item         if item?
+    xtra['name_context'] = name_context if name_context?
+    xtra['is_main']      = true         if slot.isMain()
   url + ( (if url.match /\?/ then '&' else '?') + $.param(xtra) )
 
 jQuery.fn.extend {

--- a/app/assets/stylesheets/card.css
+++ b/app/assets/stylesheets/card.css
@@ -357,7 +357,6 @@ body#wagn .card-slot.recent-changes h2 {
   margin: 1px 0 0 0;
 }
 .closed-view .card-header {
-  padding: auto 12px;
   vertical-align: middle;
   display: inline-block;
   line-height: 15px;
@@ -466,10 +465,11 @@ ul.pointer {
 }
 .pointer-list-editor input {
   margin-right: 10px;
-  width: 60%;
+  width: 65%;
 }
 .pointer-list-editor li {
   list-style: none;
+  white-space: nowrap;
 }
 .pointer-list-editor .pointer-item-delete {
   margin-left: 4px;

--- a/lib/wagn/renderer/html.rb
+++ b/lib/wagn/renderer/html.rb
@@ -113,7 +113,11 @@ module Wagn
         attributes['card-id']  = card.id
         attributes['card-name'] = card.name
       end
-
+      
+      if @context_names
+        attributes['name_context'] = @context_names.map( &:key ) * ','
+      end
+      
       content_tag(:div, attributes ) { yield }
     end
 
@@ -246,8 +250,13 @@ module Wagn
     end
 
     def fieldset title, content, opts={}
+      if attribs = opts[:attribs]
+        attrib_string = attribs.keys.map do |key| 
+          %{#{key}="#{attribs[key]}"}
+        end * ' '
+      end
       %{
-        <fieldset #{ opts[:attribs] }>
+        <fieldset #{ attrib_string }>
           <legend>
             <h2>#{ title }</h2>
             #{ help_text *opts[:help] }

--- a/lib/wagn/set/all/rich_html.rb
+++ b/lib/wagn/set/all/rich_html.rb
@@ -45,7 +45,7 @@ module Wagn
     end
   
     define_view :title do |args|
-      t = content_tag :h1, fancy_title, :class=>'card-title', :name_context=>"#{ @context_names.map(&:key)*',' }"
+      t = content_tag :h1, fancy_title, :class=>'card-title'
       add_name_context
       t
     end
@@ -313,7 +313,7 @@ module Wagn
         else
           type_field :class=>"type-field live-type-field", :href=>path(:view=>:new), 'data-remote'=>true
         end
-      end)
+      end), :attribs=> { :class=>'type-fieldset'}
     end
 
     define_view :edit_type, :perms=>:update do |args|
@@ -344,7 +344,7 @@ module Wagn
     define_view :edit_in_form, :perms=>:update, :tags=>:unknown_ok do |args|
       eform = form_for_multi
       content = content_field eform, :nested=>true
-      attribs = %{ class="card-editor RIGHT-#{ card.cardname.tag_name.safe_key }" }
+      attribs = { :class=> "card-editor RIGHT-#{ card.cardname.tag_name.safe_key }" }
       link_target, help_settings = if card.new_card?
         content += raw( "\n #{ eform.hidden_field :type_id }" )
         [ card.cardname.tag, [:add_help, { :fallback => :edit_help } ] ]


### PR DESCRIPTION
before you could click on links like "Add +discussion" and then you would get this card with a crazy long name like "My ticket with a crazy long name+discussion". 

This patch makes it so that context names are stored in the slot and preserved across requests.
