### PR TITLE
better interface for permission inheritance

### DIFF
--- a/app/assets/stylesheets/card.css
+++ b/app/assets/stylesheets/card.css
@@ -145,19 +145,7 @@ a.email-link {
   color: #069;
   background: #ffc;
 }
-/*
-.content-view p,
-.content-view span,
-.content-view a,
-.content-view ul,
-.content-view ol,
-.content-view h1,
-.content-view h2 {
-  background-color: inherit;
-  -moz-border-radius: inherit;
-  border-radius: inherit;
-}
-*/
+
 
 /* note:   ".card-slot .content-view div not(.editor)" was not working properly and was breaking nested block elements.
    without it nested divs in content-view areas probably won't highlight  */
@@ -529,7 +517,6 @@ div.search-result-list .search-result-item {
 /*-----------( Image ) -----------*/
 
 
-/*.open-view.type-Image, */
 .open-view .TYPE-image .content {
 /*  overflow: auto;  */
   padding: 5px;

--- a/lib/wagn/set/right/rstar.rb
+++ b/lib/wagn/set/right/rstar.rb
@@ -7,6 +7,11 @@ include Sets
     define_view :closed_rule, :rstar=>true, :tags=>:unknown_ok do |args|
       rule_card = card.new_card? ? find_current_rule_card[0] : card
 
+      rule_content = !rule_card ? '' : begin
+        r = subrenderer rule_card
+        r.render_closed_content :set_context=>card.cardname.trunk_name
+      end
+
       cells = [
         ["rule-setting",
           link_to( card.cardname.tag.sub(/^\*/,''), path(:view=>:open_rule),
@@ -14,7 +19,7 @@ include Sets
         ],
         ["rule-content",
           %{<div class="rule-content-container">
-             <span class="closed-content content">#{rule_card ? subrenderer(rule_card).render_closed_content : ''}</span>
+             <span class="closed-content content">#{rule_content}</span>
            </div> } ],
         ["rule-type", (rule_card ? rule_card.type_name : '') ],
       ]


### PR DESCRIPTION
on *self sets (which is what you usually see when you go to "advanced" / options view), we were showing "Inherit from left card" as the permissions value.  now you see actual card name.
