### PR TITLE
Adding symbol :add_help into hash.  The migration at ruby 1.8.7 will fail

### DIFF
--- a/lib/wagn/set/all/rich_html.rb
+++ b/lib/wagn/set/all/rich_html.rb
@@ -535,7 +535,7 @@ module Wagn
       text = if args[:text]
         args[:text]
       elsif setting = args[:setting]
-        setting = [ :add_help, :fallback => :help ] if setting == :add_help
+        setting = [ :add_help => :add_help, :fallback => :help ] if setting == :add_help
         if help_card = card.rule_card( *setting ) and help_card.ok? :read
           with_inclusion_mode :normal do
             _final_core args.merge( :structure=>help_card.name )


### PR DESCRIPTION
Without assigning value to symbol :add_help it will not run under ruby 1.8.7.  Both 1.9.3 and 2.0.0 will accept the symbol without any assignment.
The `bundle exec rake wagn:migrate` command will fail (with syntax error, unexpected tASSOC, expecting ']') without this patch.
