### PR TITLE
Error that prevents update from 11.1 to 11.3 wagn

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -91,7 +91,7 @@ class Card < ActiveRecord::Base
       file_ids.each do |file_id|
         if !card_ids.member?(file_id)
           raise Wagn::Error, "Narrowly averted deleting current file" if Card.exists?(file_id) #double check!
-          FileUtils.rm_rf("#{dir}/#{file_id}", secure: true)
+          FileUtils.rm_rf("#{dir}/#{file_id}", :secure => true)
         end
       end
     end


### PR DESCRIPTION
I have checked the doc for FileUtils & rm_rf method.  This is probably correct assigment for the :secure.

This error came up when I tried to update to the latest wagn.

Take care Ethan.
