### PR TITLE
SSL only installations redirect to non-SSL for special URLs like *previous

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
 
       # these should not be Wagn::Conf, but more like WagnEnv
       Wagn::Conf[:host] = host = request.env['HTTP_HOST']
-      Wagn::Conf[:base_url] = 'http://' + host
+      Wagn::Conf[:base_url] = request.protocol + host
       Wagn::Conf[:main_name] = nil
       Wagn::Conf[:controller] = self
 

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -67,7 +67,7 @@ module LocationHelper
   end
 
   def wagn_url rel #should be in smartname?
-    rel =~ /^http\:/ ? rel : "#{Wagn::Conf[:base_url]}#{wagn_path(rel)}"
+    rel =~ /^https?\:/ ? rel : "#{Wagn::Conf[:base_url]}#{wagn_path(rel)}"
   end
 
 


### PR DESCRIPTION
base_url should not default to http, but rather default to the protocol of the request being processed. Additionally, url matching should optionally match https in wagn_url
