### PR TITLE
Migratecards

### DIFF
--- a/lib/tasks/wagn.rake
+++ b/lib/tasks/wagn.rake
@@ -90,6 +90,7 @@ namespace :wagn do
     desc "migrate cards"
     task :cards => :environment do
       Wagn::Conf[:migration] = true
+      Card # this is needed in production mode to insure core db structures are loaded before schema_mode is set
     
       paths = ActiveRecord::Migrator.migrations_paths = Wagn::MigrationHelper.card_migration_paths
     


### PR DESCRIPTION
one-line fix for card migrations issue.  (wagn:migrate was failing on new cldstr sites.  not actually causing major issues, but not good).

I'm not wild about just sticking constants in random places, but this is a hard-to-test issue and I wanted to push it through pretty quickly.

figure it might also work to stick a require_dependency in the middle of the task?  That's a bit clearer but I wasn't sure...
