### PR TITLE
Baseviews

### DIFF
--- a/spec/pack/standard/sets/rstar/rules_spec.rb
+++ b/spec/pack/standard/sets/rstar/rules_spec.rb
@@ -3,9 +3,10 @@ require 'wagn/spec_helper'
 
 describe Card::Set::Rstar::Rules do
   it "should render setting view for a right set" do
-     r = Card::Format.new(Card['*read+*right']).render
+     r = Card::Format.new(Card['*read+*right']).render_open
      r.should_not match(/error/i)
      r.should_not match('No Card!')
+     #warn "r = #{r}"
      assert_view_select r, 'table[class="set-rules"]' do
        assert_select 'a[href~="/*read+*right+*input?view=open_rule"]', :text => 'input'
      end


### PR DESCRIPTION
inspired by http://wagn.org/view_type_labeled_fails_to_convert_properly

pr adds support for open, closed, and labeled in the base format class; none of these were supported before, leading to breakage from explicit views in inclusions in non-html formats.

also re-arranged define_view and alias_view a bit to make it so that you can now define an unknown view via aliasing (not previously possible).  This is especially key in the base class.
