### PR TITLE
Update to use debugger vs. ruby-debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,15 +70,7 @@ end
 gem 'ruby-prof', '~>0.12.1', :group=>:profile  # profiling
 
 group :debug do
-  case RUBY_VERSION
-  when /^1\.9\.3-p0/
-    gem 'linecache19', '~>0.5.13'
-    gem 'ruby-debug-base19x', '~> 0.11.30.pre4'
-  when /^1\.9/
-    gem 'ruby-debug19', :require => 'ruby-debug'
-  when /^1\.8/
-    gem 'ruby-debug'
-  end
+  gem 'debugger'
 end
 
 

--- a/features/step_definitions/wagn_steps.rb
+++ b/features/step_definitions/wagn_steps.rb
@@ -2,6 +2,7 @@
 require 'uri'
 require 'cgi'
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "paths"))
+require 'debugger'
 
 
 Given /^site simulates setup need$/ do
@@ -134,6 +135,7 @@ end
 
 Then /debug/ do
   debugger
+  nil
 end
 
 


### PR DESCRIPTION
Also, when trying to use development env, sprockets doesn't find jquery-ui with latest gem versions.  Changed it to jquery.ui.all and it works now.
