### PR TITLE
move key WQL restrictions from WHERE/IN to JOIN

### DIFF
--- a/lib/card/query.rb
+++ b/lib/card/query.rb
@@ -27,7 +27,6 @@ class Card::Query
   end
 
   def run
-    puts "running sql: #{sql}"
     rows = ActiveRecord::Base.connection.select_all( sql )
     retrn = query[:return].present? ? query[:return].to_s : 'card'
     case retrn 
@@ -67,10 +66,9 @@ class Card::Query
     end
 
     def to_s
-      "(
-select #{fields.reject(&:blank?).join(', ')} from #{tables} #{joins.join(' ')}
-where #{conditions.reject(&:blank?).join(' and ')} #{group} #{order} #{limit} #{offset}
-)"
+      select = fields.reject(&:blank?) * ', '
+      where = conditions.reject(&:blank?) * ' and '
+      ['(SELECT', select, 'FROM', tables, joins, 'WHERE', where, group, order, limit, offset, ')'].compact * ' '
     end
   end
 

--- a/lib/card/query/card_spec.rb
+++ b/lib/card/query/card_spec.rb
@@ -237,27 +237,21 @@ class Card
 
       #~~~~~~ PLUS RELATIONAL
 
-      def left_plus(val)
-       
-#        merge( field(:id) => subspec(junc_spec, :return=>'right_id', :left =>part_spec))
-#        restrict :id, junc_spec.merge(:left=>part_spec), :return=>'right_id'
-        restrict :id, junction(:left, val), :return=>'right_id'
+      def left_plus val
+        junction :left, val
       end
 
-      def right_plus(val)
-#        part_spec, junc_spec = val.is_a?(Array) ? val : [ val, {} ]
-#        merge( field(:id) => subspec(junc_spec, :return=>'left_id', :right=> part_spec ))
-        restrict :id, junction(:right, val), :return=>'left_id'
-        
+      def right_plus val
+        junction :right, val
       end
 
-      def plus(val)
-        subcondition( { :left_plus=>val, :right_plus=>val.deep_clone }, :conj=>:or )
+      def plus val
+        any( { :left_plus=>val, :right_plus=>val.deep_clone } )
       end
-    
+      
       def junction side, val
         part_spec, junction_spec = val.is_a?(Array) ? val : [ val, {} ]
-        junction_spec.merge( side => part_spec )      
+        restrict_by_join :id, junction_spec, side=>part_spec, :return=>"#{ side==:left ? :right : :left}_id"
       end
     
     
@@ -290,12 +284,14 @@ class Card
           unless c && [SearchTypeID,SetID].include?(c.type_id)
             raise BadQuery, %{"found_by" value needs to be valid Search, but #{c.name} is a #{c.type_name}}
           end
-          restrict :id, CardSpec.new(c.get_spec).rawspec
+          restrict_by_join :id, CardSpec.new(c.get_spec).rawspec
         end
       end
   
       def not val
-        merge field(:id) => subspec( val, {:return=>'id'}, negate=true )
+        subselect = CardSpec.build(:return=>:id, :_parent=>self).merge(val).to_sql
+        join_alias = add_join :not, subselect, :id, :id, :side=>'LEFT'        
+        merge field(:cond) => SqlCond.new("#{join_alias}.id is null")
       end
 
       def sort val
@@ -305,7 +301,7 @@ class Card
         item = val.delete(:item) || 'left'
 
         if val[:return] == 'count'
-          cs_args = { :return=>'count', :group=>'sort_join_field' }
+          cs_args = { :return=>'count', :group=>'sort_join_field', :_parent=>self }
           @mods[:sort] = "coalesce(#{@mods[:sort]},0)"
           case item
           when 'referred_to'
@@ -377,7 +373,12 @@ class Card
 
       def add_join(name, table, cardfield, otherfield, opts={})
         join_alias = "#{table_alias}_#{name}"
-        @joins[join_alias] = "#{opts[:side]} JOIN #{table} AS #{join_alias} ON #{table_alias}.#{cardfield} = #{join_alias}.#{otherfield}"
+        on = "#{table_alias}.#{cardfield} = #{join_alias}.#{otherfield}"
+        if @mods[:conj] == 'or'
+          opts[:side] ||= 'LEFT'
+          merge field(:cond) => SqlCond.new(on)
+        end
+        @joins[join_alias] = ["\n  ", opts[:side], 'JOIN', table, 'AS', join_alias, 'ON', on, "\n"].compact.join ' '
         join_alias
       end
 
@@ -397,26 +398,13 @@ class Card
         cardspec = CardSpec.build( args )
         merge field(:cond) => cardspec.merge(val)
         self.joins.merge! cardspec.joins
-      end
-
-      # def revision_spec(field, linkfield, val)
-#         card_select = CardSpec.build(:_parent=>self, :return=>'id').merge(val).to_sql
-#         add_join :ed, "(select distinct #{field} from card_revisions where #{linkfield} in #{card_select})", :id, field
-#       end
-      
+      end      
       
       def action_spec(field, linkfield, val)
         card_select = CardSpec.build(:_parent=>self, :return=>'id').merge(val).to_sql
         sql =  "(SELECT DISTINCT #{field} AS join_card_id FROM card_acts INNER JOIN card_actions ON card_acts.id = card_act_id "
         sql += " JOIN (#{card_select}) AS ss ON #{linkfield}=ss.id AND (draft=0 OR draft IS NULL))"
         add_join :ac, sql, :id, :join_card_id
-      end
-
-
-      def subspec(spec, additions={ :return=>'id'}, negate=false)
-        additions = additions.merge(:_parent=>self)
-        operator = negate ? 'not in' : 'in'
-        ValueSpec.new([operator,CardSpec.build(additions).merge(spec)], self)
       end
 
       def id_from_spec spec
@@ -435,9 +423,9 @@ class Card
       end
       
       def restrict_by_join id_field, val, opts={}
-        opts[:return] ||= :id  
+        opts.reverse_merge!(:return=>:id, :_parent=>self)
         subselect = CardSpec.build(opts).merge(val).to_sql
-        add_join "#{ field id_field }_tbl", "(#{subselect})", id_field, opts[:return]
+        add_join "#{ field id_field }_tbl", subselect, id_field, opts[:return]
       end
     
       #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -448,7 +436,10 @@ class Card
       def to_sql *args
         sql.conditions << basic_conditions
 
-        return "(" + sql.conditions.last + ")" if @mods[:return]=='condition'
+        if @mods[:return]=='condition'
+          conds = sql.conditions.last
+          return conds.blank? ? nil : "(#{conds})"
+        end
     
         if pconds = permission_conditions
           sql.conditions << pconds

--- a/spec/lib/card/query_spec.rb
+++ b/spec/lib/card/query_spec.rb
@@ -70,7 +70,6 @@ describe Card::Query do
     end
 
     it "should handle multiple values for plus_relational keys" do
-      puts "expecting...."
       expect(Card::Query.new( :right_plus=>[ :all, 'e', 'c' ], :return=>:name ).run.sort).to eq(%w{ A }) #explicit conjunction
       expect(Card::Query.new( :right_plus=>[ ['e',{}],  'c' ], :return=>:name ).run.sort).to eq(%w{ A }) # first element is array
       expect(Card::Query.new( :right_plus=>[ 'e', 'c'       ], :return=>:name ).run.sort).to eq([])      # NOT interpreted as multi-value


### PR DESCRIPTION
We were seeing order of magnitude performance impacts for using things like this:

```
...WHERE type_id IN (SELECT id from cards....
```

instead of this:

```
..JOIN (select id from cards...) AS type_table ON cards.type_id = type_table.id
```

This PR attempts to implement and generalize that approach.
