### PR TITLE
fix for fetching virtual cards

### DIFF
--- a/mod/01_core/set/all/fetch.rb
+++ b/mod/01_core/set/all/fetch.rb
@@ -57,7 +57,7 @@ module ClassMethods
       else
         card.include_set_modules unless opts[:skip_modules]  # need to load modules here to call the right virtual? method 
         opts[:skip_modules] = true                           # don't load twice
-        return unless !opts[:skip_virtual] && card.virtual?
+        return if opts[:skip_virtual] || !card.virtual?
       end
       card.name = mark.to_s if mark && mark.to_s != card.name
     end

--- a/mod/01_core/set/all/fetch.rb
+++ b/mod/01_core/set/all/fetch.rb
@@ -55,6 +55,8 @@ module ClassMethods
       if opts[:new]
         return card.renew(opts) if !clean_cache_opts? opts
       else
+        card.include_set_modules unless opts[:skip_modules]  # need to load modules here to call the right virtual? method 
+        opts[:skip_modules] = true                           # don't load twice
         return unless !opts[:skip_virtual] && card.virtual?
       end
       card.name = mark.to_s if mark && mark.to_s != card.name

--- a/mod/01_core/set/all/fetch.rb
+++ b/mod/01_core/set/all/fetch.rb
@@ -54,10 +54,11 @@ module ClassMethods
     if card.new_card?
       if opts[:new]
         return card.renew(opts) if !clean_cache_opts? opts
+      elsif opts[:skip_virtual]
+        return
       else
         card.include_set_modules unless opts[:skip_modules]  # need to load modules here to call the right virtual? method 
-        opts[:skip_modules] = true                           # don't load twice
-        return if opts[:skip_virtual] || !card.virtual?
+        return unless card.virtual?
       end
       card.name = mark.to_s if mark && mark.to_s != card.name
     end


### PR DESCRIPTION
this fixes a problem that affects the upcoming following stuff.
There are cards that are defined to be virtual by code rules, e.g. 
right/followers.rb:
````ruby
def virtual?; true end
````

`Card.fetch "Home+*followers"` returns nil because the set modules are loaded after the virtual check.