### PR TITLE
fix *default handling bug

### DIFF
--- a/mod/01_core/set/all/content.rb
+++ b/mod/01_core/set/all/content.rb
@@ -16,7 +16,7 @@ def content=(value)
 end
 
 def raw_content
-  structure ? template.db_content : db_content
+  structure ? template.db_content : content
 end
 
 

--- a/mod/01_core/spec/set/all/templating_spec.rb
+++ b/mod/01_core/spec/set/all/templating_spec.rb
@@ -57,6 +57,7 @@ describe Card::Set::All::Templating do
       Card::Auth.as_bot  do
         @bt = Card.create! :name=>"birthday+*right+*default", :type=>'Date', :content=>"Today!"
       end
+      @bb = Card.new :name=>'Bob+birthday'
       @jb = Card.create! :name=>"Jim+birthday"
     end
 
@@ -69,7 +70,9 @@ describe Card::Set::All::Templating do
     end
     
     it "should apply to new cards" do
-      expect(Card.new(:name=>"Pete+birthday").content).to eq('Today!')
+      pb = Card.new :name=>"Pete+birthday"
+      expect(pb.raw_content).to eq('Today!')
+      expect(pb.content).to eq('Today!')
     end
   end
 


### PR DESCRIPTION
This is fairly critical, because it fixes brokenness in setting default content in forms (eg wagn.org/new/Ticket, in which +status should default to "open", based on the existing *default rule)