### PR TITLE
Routes - back to gem

### DIFF
--- a/card/spec/lib/card/cache_spec.rb
+++ b/card/spec/lib/card/cache_spec.rb
@@ -76,7 +76,7 @@ describe Card::Cache do
 
   describe "with file store" do
     before do
-      cache_path = "#{Decko.root}/tmp/cache"
+      cache_path = "#{Decko::Rails.root}/tmp/cache"
       unless File.directory?(cache_path)
         FileUtils.mkdir_p(cache_path)
       end

--- a/decko-rails/lib/decko/engine.rb
+++ b/decko-rails/lib/decko/engine.rb
@@ -12,7 +12,6 @@ require 'kaminari'
 require 'diff/lcs'
 require 'diffy'
 
-DECKO_GEM_ROOT = File.expand_path('../../..', __FILE__)
 
 module Decko
 
@@ -27,7 +26,7 @@ module Decko
 
   end
 
-  class Decko::Engine < Rails::Engine
+  class Engine < ::Rails::Engine
     
     paths.add "app/controllers", :eager_load => true
     paths.add 'gem-assets',      :with => 'public/assets'
@@ -39,17 +38,17 @@ module Decko
           Decko::Engine.paths['request_log'] = Wagn.paths['request_log']
           Decko::Engine.paths['log']         = Wagn.paths['log']
         else
-          Cardio.card_config Rails.application.config
+          Cardio.card_config ::Rails.application.config
         end
-        Cardio.cache == Rails.cache
+        Cardio.cache == ::Rails.cache
         
-        ActiveRecord::Base.establish_connection(Rails.env)
+        ActiveRecord::Base.establish_connection(::Rails.env)
       end
       ActiveSupport.on_load(:after_initialize) do
         begin
           require_dependency 'card' unless defined?(Card)
         rescue ActiveRecord::StatementInvalid => e
-          Rails.logger.warn "database not available[#{Rails.env}] #{e}"
+          ::Rails.logger.warn "database not available[#{::Rails.env}] #{e}"
         end
       end
     end

--- a/decko-rails/lib/decko/rails.rb
+++ b/decko-rails/lib/decko/rails.rb
@@ -1,0 +1,15 @@
+DECKO_RAILS_GEM_ROOT = File.expand_path('../../..', __FILE__)
+
+module Decko
+  module Rails
+    class << self
+      def root
+        ::Rails.root
+      end
+
+      def gem_root
+        DECKO_RAILS_GEM_ROOT
+      end
+    end
+  end
+end

--- a/wagn/lib/wagn/application.rb
+++ b/wagn/lib/wagn/application.rb
@@ -84,14 +84,14 @@ module Wagn
         
         paths.add 'files'
         
+        #more consistent to call this deck mod...
         paths.add 'local-mod', :with=>'mod'
         paths['app/models'] = []
         paths['app/mailers'] = []
         
-    
-        # should we have add_deck_paths for these?
-        add_gem_path paths, "lib/tasks",           :with => "lib/wagn/tasks", :glob => "**/*.rake"
+        add_gem_path paths, "lib/tasks",     :with => "lib/wagn/tasks", :glob => "**/*.rake"
         add_gem_path paths, 'gem-assets'
+        add_gem_path paths, 'config/routes', :with => 'lib/wagn/config/routes.rb'
         
         paths
       end

--- a/wagn/lib/wagn/config/routes.rb
+++ b/wagn/lib/wagn/config/routes.rb
@@ -1,0 +1,3 @@
+Wagn.application.routes.draw do
+  mount Decko::Engine => '/'
+end

--- a/wagn/lib/wagn/config/routes.rb
+++ b/wagn/lib/wagn/config/routes.rb
@@ -1,3 +1,6 @@
 Wagn.application.routes.draw do
+  if !Rails.env.production? && Object.const_defined?( :JasmineRails )
+    mount Object.const_get(:JasmineRails).const_get(:Engine) => "/specs"
+  end
   mount Decko::Engine => '/'
 end

--- a/wagn/lib/wagn/generators/wagn/templates/Gemfile
+++ b/wagn/lib/wagn/generators/wagn/templates/Gemfile
@@ -38,11 +38,11 @@ group :test, :development do
   # gem 'pry-rescue'
   # gem 'pry-stack_explorer'
   if RUBY_VERSION =~ /^2/
-		gem 'byebug' 
-    # gem 'pry-byebug'
-	else
-		gem 'debugger'
-	end
+  gem 'byebug' 
+  # gem 'pry-byebug'
+  else
+    gem 'debugger'
+  end
 end
 
 <% end -%>

--- a/wagn/lib/wagn/generators/wagn/templates/config/routes.erb
+++ b/wagn/lib/wagn/generators/wagn/templates/config/routes.erb
@@ -1,8 +1,6 @@
 # -*- encoding : utf-8 -*-
 
-require 'decko/engine'
-
-Rails.application.routes.draw do
+Wagn.application.routes.draw do
 <% if @include_jasmine_engine %>
   if !Rails.env.production? && Object.const_defined?( :JasmineRails )
     mount Object.const_get(:JasmineRails).const_get(:Engine) => "<%= decko_path %>/specs"

--- a/wagn/lib/wagn/generators/wagn/wagn_generator.rb
+++ b/wagn/lib/wagn/generators/wagn/wagn_generator.rb
@@ -16,7 +16,7 @@ class WagnGenerator < Rails::Generators::AppBase
     desc: "Prepare deck for wagn core testing"
     
   class_option 'gem-path', :type => :string, aliases: '-g', :default => false, :group => :runtime, 
-    desc: "Path to local gem installation (Default, use env WAGN_DEV_GEM_PATH)"
+    desc: "Path to local gem installation (Default, use env WAGN_GEM_PATH)"
     
   class_option 'mod-dev', :type => :boolean, aliases: '-m', :default => false, :group => :runtime, 
     desc: "Prepare deck for mod testing"
@@ -30,9 +30,9 @@ class WagnGenerator < Rails::Generators::AppBase
   def dev_setup
     # TODO: rename or split, gem_path points to the source repo, card and wagn gems are subdirs
     @gemfile_gem_path = @gem_path = options['gem-path']
-    env_gem_path = ENV['WAGN_DEV_GEM_PATH']
+    env_gem_path = ENV['WAGN_GEM_PATH']
     if env_gem_path.present?
-      @gemfile_gem_path = %q{#{ENV['WAGN_DEV_GEM_PATH']}}
+      @gemfile_gem_path = %q{#{ENV['WAGN_GEM_PATH']}}
       @gem_path = env_gem_path
     end
     


### PR DESCRIPTION
also moved Decko.gem_root (et al) to Decko::Rails.gem_root.  Much more forward compatible, since Wagn will soon be Decko!