### PR TITLE
log cache clearing issues

### DIFF
--- a/card/lib/card/cache.rb
+++ b/card/lib/card/cache.rb
@@ -175,7 +175,11 @@ class Card
       @cache_id = self.class.generate_cache_id
       if @store
         if hard
-          @store.clear
+          begin
+            @store.clear
+          rescue => e
+            Rails.logger.debug "Problem clearing cache: #{e.message}"
+          end
         else
           @store.write @system_prefix + "cache_id", @cache_id
         end


### PR DESCRIPTION
This rescues a case where the cache is cleared when there's nothing in it. You can trigger it with wagn update. Maybe reset_global gets called twice in a row somehow?

The rescue is fine, I suppose...