### PR TITLE
Fastfollow

### DIFF
--- a/card/lib/card/name.rb
+++ b/card/lib/card/name.rb
@@ -37,5 +37,9 @@ class Card
       name = trait_name( tag_code )
       name ? name.s : ( raise Card::NotFound, "unknown codename: #{tag_code}" )
     end
+    
+    def code
+      Codename[ Card.fetch_id self ]
+    end
   end
 end

--- a/card/lib/cardio.rb
+++ b/card/lib/cardio.rb
@@ -25,7 +25,7 @@ module Cardio
     def set_config config
       @@config = config
       @@root = @@config.root
-        
+
       config.autoload_paths += Dir["#{Cardio.gem_root}/mod/*/lib/**/"]
 
       config.read_only             = !!ENV['WAGN_READ_ONLY']

--- a/card/mod/01_core/set/all/rules.rb
+++ b/card/mod/01_core/set/all/rules.rb
@@ -23,19 +23,20 @@ def is_rule?
 end
 
 def is_standard_rule?
-  (l = left( :skip_modules=>true ))  &&
-  l.type_id == Card::SetID           &&
   (r = right( :skip_modules=>true )) &&
-  r.type_id == Card::SettingID           
+  r.type_id == Card::SettingID       &&
+  (l = left( :skip_modules=>true ))  &&
+  l.type_id == Card::SetID
 end
 
 def is_user_rule?
+  cardname.parts.length > 2                                  &&
+  (r = right( :skip_modules=>true ))                         &&
+   r.type_id == Card::SettingID                              &&
   (set = self[0..-3, :skip_modules=>true])                   &&
    set.type_id == Card::SetID                                && 
   (user = self[-2, :skip_modules=>true] )                    &&
-  (user.type_id == Card::UserID  || user.codename == 'all' ) &&
-  (r = right( :skip_modules=>true ))                         &&
-   r.type_id == Card::SettingID
+  (user.type_id == Card::UserID  || user.codename == 'all' )
 end
 
 

--- a/card/mod/03_machines/lib/javascript/wagn_mod.js.coffee
+++ b/card/mod/03_machines/lib/javascript/wagn_mod.js.coffee
@@ -304,6 +304,7 @@ $(window).ready ->
        $(this).addClass("btn-primary").removeClass("btn-danger"))
 
   $('body').on 'click', '.follow-toggle', ->
+    alert 'got here!!'
     anchor = $(this)
     url  = wagn.rootPath + '/update/' + anchor.data('rule_name') + '.json'
     $.ajax url, {

--- a/card/mod/03_machines/lib/javascript/wagn_mod.js.coffee
+++ b/card/mod/03_machines/lib/javascript/wagn_mod.js.coffee
@@ -304,7 +304,6 @@ $(window).ready ->
        $(this).addClass("btn-primary").removeClass("btn-danger"))
 
   $('body').on 'click', '.follow-toggle', ->
-    alert 'got here!!'
     anchor = $(this)
     url  = wagn.rootPath + '/update/' + anchor.data('rule_name') + '.json'
     $.ajax url, {

--- a/card/mod/03_machines/set/right/machine_output.rb
+++ b/card/mod/03_machines/set/right/machine_output.rb
@@ -1,7 +1,7 @@
 format do
   view :not_found do |args|
     if update_machine_output_live?
-      Card::Cache.reset_global
+      Card::Cache.reset_global # FIXME - wow, this kind of hard core, no?
       root.error_status = 302
       card.left.update_machine_output
       card_path card.left.machine_output_url

--- a/card/mod/04_settings/set/type/setting.rb
+++ b/card/mod/04_settings/set/type/setting.rb
@@ -1,4 +1,5 @@
 require_dependency 'json'
+  
 
 view :core do |args|
 

--- a/card/mod/05_email/lib/card/follow_option.rb
+++ b/card/mod/05_email/lib/card/follow_option.rb
@@ -3,9 +3,10 @@
 
 class Card
   module FollowOption
-    mattr_reader :test
+    mattr_reader :test, :test_option
+    @@test, @@test_option = {}, {}
+    
     @@options = { :all=>[], :main=>[], :restrictive=>[] }
-    @@test = {}
     
     def self.included(host_class)     
        host_class.extend ClassMethods
@@ -52,6 +53,10 @@ class Card
       def follow_test opts={}, &block
         codename = get_codename opts
         Card::FollowOption.test[codename] = block
+      end
+      
+      def follow_test_option option, &block
+        Card::FollowOption.test_option[option] = block
       end
       
       private

--- a/card/mod/05_email/lib/card/follow_option.rb
+++ b/card/mod/05_email/lib/card/follow_option.rb
@@ -3,8 +3,9 @@
 
 class Card
   module FollowOption
-    #mattr_reader :codenames
+    mattr_reader :test
     @@options = { :all=>[], :main=>[], :restrictive=>[] }
+    @@test = {}
     
     def self.included(host_class)     
        host_class.extend ClassMethods
@@ -48,6 +49,11 @@ class Card
         add_option args, :main
       end
       
+      def follow_test opts={}, &block
+        codename = get_codename opts
+        Card::FollowOption.test[codename] = block
+      end
+      
       private
       
       def insert_option pos, item, type
@@ -60,8 +66,8 @@ class Card
         end
       end
       
-      def add_option opts, type
-        codename = opts[:codename] || self.name.match(/::(\w+)$/)[1].underscore.to_sym
+      def add_option opts, type, &block
+        codename = get_codename opts
         if opts[:position]
           insert_option opts[:position]-1, codename, type
         else
@@ -69,6 +75,11 @@ class Card
         end
         Card::FollowOption.codenames(:all) << codename
       end
+      
+      def get_codename opts
+        opts[:codename] || self.name.match(/::(\w+)$/)[1].underscore.to_sym
+      end
+      
       
     end   
   end

--- a/card/mod/05_email/set/all/follow.rb
+++ b/card/mod/05_email/set/all/follow.rb
@@ -103,12 +103,8 @@ def followed_by? user_id
     if follow_rule_applies? user_id
       return true
     end
-    left_card = left
-    while left_card
-      if left_card.followed_field?(self) && left_card.followed_by?(user_id)
-        return true
-      end
-      left_card = left_card.left
+    if left_card = left and left_card.followed_field?(self) && left_card.followed_by?(user_id)
+      return true
     end
     return false
   end

--- a/card/mod/05_email/set/all/notify.rb
+++ b/card/mod/05_email/set/all/notify.rb
@@ -74,7 +74,7 @@ event :notify_followers, :after=>:extend, :when=>proc{ |c|
     end
     @follower_stash.each_follower_with_reason do |follower, reason|
       if follower.account and follower != @current_act.actor
-        follower.account.send_change_notice @current_act, reason[:set_card].name, reason[:option_card].name
+        follower.account.send_change_notice @current_act, reason[:set_card].name, reason[:option]
       end
     end
   rescue =>e  #this error handling should apply to all extend callback exceptions

--- a/card/mod/05_email/set/all/notify.rb
+++ b/card/mod/05_email/set/all/notify.rb
@@ -28,9 +28,10 @@ class FollowerStash
             end
           end
           
-        end      
+        end 
+    
       end
-      
+
     end
   end
   

--- a/card/mod/05_email/set/self/always.rb
+++ b/card/mod/05_email/set/self/always.rb
@@ -2,7 +2,7 @@ include Card::FollowOption
 
 self.follow_opts :position=>2
 
-def applies_to? card, user_id
+self.follow_test do |opts|
   true
 end
 

--- a/card/mod/05_email/set/self/always.rb
+++ b/card/mod/05_email/set/self/always.rb
@@ -2,9 +2,7 @@ include Card::FollowOption
 
 self.follow_opts :position=>2
 
-self.follow_test do |opts|
-  true
-end
+self.follow_test { true }
 
 def title
   'Following'

--- a/card/mod/05_email/set/self/created.rb
+++ b/card/mod/05_email/set/self/created.rb
@@ -2,9 +2,17 @@ include Card::FollowOption
 
 self.restrictive_follow_opts :position=>1
 
-def applies_to? card, user_id
-  card.creator and card.creator.type_id == Card::UserID and card.creator.id == user_id
+self.follow_test do |opts|
+  opts[:creator_id] == opts[:user_id]
 end
+
+self.follow_test_option :creator_id do |card|
+  card.creator_id
+end
+
+#def applies_to? card, user_id
+#  card.creator and card.creator.type_id == Card::UserID and card.creator.id == user_id
+#end
 
 def title
   'Following content you created'

--- a/card/mod/05_email/set/self/edited.rb
+++ b/card/mod/05_email/set/self/edited.rb
@@ -2,10 +2,14 @@ include Card::FollowOption
 
 self.restrictive_follow_opts :position=>2
 
-def applies_to? card, user_id
-  #return false
-  card.editor_ids_follow_cache.find { |editor_id| editor_id.to_i == user_id }
+self.follow_test do |opts|
+  opts[:editor_ids].find { |editor_id| editor_id == opts[:user_id] }
 end
+
+self.follow_test_option :editor_ids do |card|
+  Card.search( :editor_of=>card.name, :return=>:id ).map &:to_i
+end
+
 
 def title 
   'Following content you edited'

--- a/card/mod/05_email/set/self/edited.rb
+++ b/card/mod/05_email/set/self/edited.rb
@@ -3,7 +3,8 @@ include Card::FollowOption
 self.restrictive_follow_opts :position=>2
 
 def applies_to? card, user_id
-  Card.search(:editor_of=>card.name, :return=>:id).find { |editor_id| editor_id.to_i == user_id }
+  #return false
+  card.editor_ids_follow_cache.find { |editor_id| editor_id.to_i == user_id }
 end
 
 def title 

--- a/card/mod/05_email/set/self/never.rb
+++ b/card/mod/05_email/set/self/never.rb
@@ -2,9 +2,10 @@ include Card::FollowOption
 
 self.follow_opts :position=>3
 
-def applies_to? card, user_id
+self.follow_test do |opts|
   false
 end
+
 
 def title
   'Ignoring'

--- a/card/mod/05_email/set/self/never.rb
+++ b/card/mod/05_email/set/self/never.rb
@@ -2,9 +2,7 @@ include Card::FollowOption
 
 self.follow_opts :position=>3
 
-self.follow_test do |opts|
-  false
-end
+self.follow_test { |opts| false }
 
 
 def title


### PR DESCRIPTION
the following functionality was proving to have a strong negative impact on performance in production, especially when there were lots of users with default "created" or "edited" rules.  It slowed down all card actions (as in, not simple read requests, but all the others) even in cases where there were notifications to send. 

The main change here is to move most of the organization around the following tests into load time (as opposed to test time).  (see follow_option.rb)