### PR TITLE
context name clearing

### DIFF
--- a/card/lib/card/format.rb
+++ b/card/lib/card/format.rb
@@ -86,14 +86,24 @@ class Card
 
       @mode  ||= :normal
       @depth ||= 0
-      @root  ||= self      
+      @root  ||= self
 
-      @context_names ||= if params[:slot] && context_name_list = params[:slot][:name_context]
-        context_name_list.split(',').map &:to_name
-      else [] end
-        
+      @context_names = get_context_names
       include_set_format_modules
       self
+    end
+    
+    def get_context_names      
+      case
+      when @context_names
+        part_keys = @card.cardname.part_names.map &:key
+        @context_names.reject { |n| !part_keys.include? n.key }
+      when params[:slot]
+        context_name_list = params[:slot][:name_context].to_s 
+        context_name_list.split(',').map &:to_name
+      else
+        []
+      end
     end
     
     def include_set_format_modules

--- a/card/mod/03_machines/lib/stylesheets/standard.scss
+++ b/card/mod/03_machines/lib/stylesheets/standard.scss
@@ -646,7 +646,7 @@ td.missing-rule {
 .rule-setting {
   padding-top: 4px;
 }
-.open-rule .rule-setting {
+.open-rule > .rule-setting {
   width: 28%;
   float: left;
 }


### PR DESCRIPTION
needed because of several cases where context names were too inclusive.

Consider: Cardtype Project includes lists of tasks (A, B, C) each of which has a +Project card.

currently, the context_name is getting passed down so that A+Project has both Project and A in its context names.  When all of a card's name parts are in the context, we give the full name as title, because we don't know what to strip.  But clearly we are really in the "A" context here (not the "Project" context).

Solution is to make it so that only parts of a card's name can be in its context.
