### PR TITLE
fixed html_args in menu items

### DIFF
--- a/card/mod/05_standard/set/all/rich_html/menu.rb
+++ b/card/mod/05_standard/set/all/rich_html/menu.rb
@@ -65,7 +65,7 @@ format :html do
   def menu_account_link args
     opts = { :related=>{:name=>'+*account',:view=>:edit},
              :path_opts=>{:slot=>{:show=>:account_toolbar}} }
-    menu_item('account', 'user',opts, args[:html_args])
+    menu_item('account', 'user',opts, args[:html_args].clone)
   end
 
   def menu_more_link args


### PR DESCRIPTION
I think this is necessary because args[:html_args] is getting altered as it's passed around