### PR TITLE
fix coverage report that doesn't include the folder/file.rb

### DIFF
--- a/card/lib/card/simplecov_helper.rb
+++ b/card/lib/card/simplecov_helper.rb
@@ -6,7 +6,7 @@ def card_simplecov_filters
 	# filter all card mods
   add_filter do |src_file|
     src_file.filename =~ /tmp\// and not
-    /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/**/#{m[1]}"].present? }
+    /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/**/#{m[1].gsub("-","/")}"].present? }
   end
 	
 	# add group for each deck mod
@@ -15,7 +15,7 @@ def card_simplecov_filters
       src_file.filename =~ /mod\/#{mod}\// or 
         (
           src_file.filename =~ /tmp\// and
-          /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/#{mod}/**/#{m[1]}"].present? } 
+          /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/#{mod}/**/#{m[1].gsub("-","/")}"].present? } 
         )
     end
   end


### PR DESCRIPTION
Example: `source/source_preview.rb` will make a file `xxxx-source-source_preview.rb`. In the old filter function, it will get the name after `-` as file name which doesn't correctly point to the real files. 