### PR TITLE
Add space/nbsp reordering on clean

### DIFF
--- a/card/config/initializers/recaptcha.rb
+++ b/card/config/initializers/recaptcha.rb
@@ -3,5 +3,5 @@ Recaptcha.configure do |config|
   config.public_key  = Cardio.config.recaptcha_public_key  || nil
   config.private_key = Cardio.config.recaptcha_private_key || nil
   config.proxy       = Cardio.config.recaptcha_proxy       || nil
-  config.api_version = 'v1'
+  config.api_version = 'v1' if config.respond_to?(:api_version=)
 end

--- a/card/lib/card/content.rb
+++ b/card/lib/card/content.rb
@@ -179,6 +179,12 @@ class Card
         end.gsub(/<\!--.*?-->/, '')
       end
 
+      if Card.config.space_last_in_multispace
+        def clean_with_space_last! string, tags = ALLOWED_TAGS
+          clean_without_space_last!(string, tags).gsub(/(?:^|\b) ((?:&nbsp;)+)/, '\1 ')
+        end
+        alias_method_chain :clean!, :space_last
+      end
       def truncatewords_with_closing_tags(input, words = 25, truncate_string = "...")
         if input.nil? then return end
         wordlist = input.to_s.split

--- a/card/lib/cardio.rb
+++ b/card/lib/cardio.rb
@@ -34,6 +34,7 @@ module Cardio
       config.recaptcha_public_key  = nil
       config.recaptcha_private_key = nil
       config.recaptcha_proxy       = nil
+      config.api_version           = 'v1'
 
       config.cache_store           = :file_store, 'tmp/cache'
       config.override_host         = nil
@@ -48,6 +49,7 @@ module Cardio
 
       config.token_expiry          = 2.days
       config.revisions_per_page    = 10
+      config.space_last_in_multispace = true
       config.closed_search_limit   = 50
     end
 

--- a/card/lib/cardio.rb
+++ b/card/lib/cardio.rb
@@ -34,7 +34,6 @@ module Cardio
       config.recaptcha_public_key  = nil
       config.recaptcha_private_key = nil
       config.recaptcha_proxy       = nil
-      config.api_version           = 'v1'
 
       config.cache_store           = :file_store, 'tmp/cache'
       config.override_host         = nil

--- a/card/spec/lib/card/content_spec.rb
+++ b/card/spec/lib/card/content_spec.rb
@@ -306,6 +306,18 @@ describe Card::Content do
         assert_equal 'yo', Card::Content.clean!('<!-- not me -->yo')
         assert_equal 'joe', Card::Content.clean!('<!-- not me -->joe<!-- not me -->')
       end
+
+      it 'fixes regular nbsp order by default' do
+        assert_equal 'space&nbsp; test&nbsp; two&nbsp;&nbsp; space',
+                      Card::Content.clean!('space&nbsp; test &nbsp;two &nbsp;&nbsp;space')
+      end
+
+      it 'doesn\'t fix regular nbsp order with setting' do
+        # manually configure this setting, then make this one live (test above will then fail)
+        pending "Can't set Card.config.space_last_in_multispace= false for one test"
+        assert_equal 'space&nbsp; test &nbsp;two &nbsp;&nbsp;space',
+                      Card::Content.clean!('space&nbsp; test &nbsp;two &nbsp;&nbsp;space')
+      end
     end
   end
   


### PR DESCRIPTION
I turned the feature on by default (it has a config to turn it off).  Can't test it on and off in one run, but the specs are there.