### PR TITLE
support nests in tabs view

### DIFF
--- a/card/db/migrate_core_cards/20141208162106_add_ace_script.rb
+++ b/card/db/migrate_core_cards/20141208162106_add_ace_script.rb
@@ -2,10 +2,8 @@
 
 class AddAceScript < Card::CoreMigration
   def up
-    all_script = Card[:all].fetch :trait=>:script
-    all_script.add_item "script: ace"
-    all_script.save!
-    
+    Card[:all].fetch(:trait=>:script).add_item!  "script: ace"
+
     Card.create! :name=>"script: ace",:codename=>"script_ace",:type=>"JavaScript"
 
   end

--- a/card/db/migrate_core_cards/20150508212032_menu_compatibility.rb
+++ b/card/db/migrate_core_cards/20150508212032_menu_compatibility.rb
@@ -7,8 +7,7 @@ class MenuCompatibility < Card::CoreMigration
     bootswatch_shared = Card[:bootswatch_shared]
     Card.search(:type_id=>Card::SkinID) do |skin|
       if skin.item_cards.find { |item_card| item_card.codename.to_s == 'style_bootstrap_compatible'}
-        skin.add_item bootswatch_shared.name
-        skin.save!
+        skin.add_item! bootswatch_shared.name
       end
     end
 

--- a/card/mod/01_core/set/all/collection.rb
+++ b/card/mod/01_core/set/all/collection.rb
@@ -189,13 +189,23 @@ format :html do
         slot_args = @inclusion_opts.clone
         slot_args.delete(:view)
         if item.kind_of? Card::Chunk::Include
-          slot_args.merge(item.options)
+          slot_args.merge!(item.options)
         end
         i_args.merge!(:slot=>slot_args)
       end
-      url = page_path(item.to_name, i_args)
-      tab_buttons += tab_button( "##{id}", item, active_tab, 'data-url'=>url.html_safe, :class=>(active_tab ? nil : 'load'))
-      tab_content = active_tab ? nest(Card.fetch(item, :new=>{}), item_args(args)) : ''
+      url = page_path(item.referee_name, i_args)
+      tab_name = (item.respond_to?(:options) && item.options[:title]) || item.name
+      tab_buttons += tab_button( "##{id}", tab_name, active_tab, 'data-url'=>url.html_safe, :class=>(active_tab ? nil : 'load'))
+      tab_content =
+        if active_tab
+          if item.kind_of? Card::Chunk::Include
+            item.process_chunk { |options| prepare_nest options }
+          else
+            nest(Card.fetch(item, :new=>{}), i_args)
+          end
+        else
+          ''
+        end
       tab_panes += tab_pane( id, tab_content, active_tab )
     end
     tab_panel tab_buttons, tab_panes, args[:tab_type]

--- a/card/mod/01_core/set/all/collection.rb
+++ b/card/mod/01_core/set/all/collection.rb
@@ -57,6 +57,27 @@ def include_item? item
   item_names.map{|name| name.to_name.key}.member? key
 end
 
+def add_item item
+  unless include_item? item
+    self.content="#{self.content}\n#{name}"
+  end
+end
+
+def drop_item item
+  if include_item? item
+    new_names = item_names.reject{ |i| i == item }
+    self.content = new_names.empty? ? '' : new_names.join("\n")
+  end
+end
+
+def insert_item index, name
+  new_names = item_names
+  new_names.delete(name)
+  new_names.insert(index,name)
+  self.content =  new_names.join "\n"
+end
+
+
 def extended_item_cards context = nil
   context = (context ? context.cardname : self.cardname)
   args={ :limit=>'' }
@@ -160,13 +181,16 @@ format :html do
   view :tabs do |args|
     tab_buttons = ''
     tab_panes = ''
-    card.item_names.each_with_index do |item, index|
+    Card::Content.new(card.content, card).find_chunks( Card::Chunk::Reference ).each_with_index do |item, index|
       active_tab = (index == 0)
-      id = "#{card.cardname.safe_key}-#{item.to_name.safe_key}"
+      id = "#{card.cardname.safe_key}-#{item.referee_name.safe_key}"
       i_args = item_args(args)
       if @inclusion_opts
         slot_args = @inclusion_opts.clone
         slot_args.delete(:view)
+        if item.kind_of? Card::Chunk::Include
+          slot_args.merge(item.options)
+        end
         i_args.merge!(:slot=>slot_args)
       end
       url = page_path(item.to_name, i_args)
@@ -176,12 +200,12 @@ format :html do
     end
     tab_panel tab_buttons, tab_panes, args[:tab_type]
   end
-  def default_tab_args args
+  def default_tabs_args args
     args[:tab_type] ||= 'tabs'
   end
 
   view :pills, :view=>:tabs
-  def default_pill_args args
+  def default_pills_args args
     args[:tab_type] ||= 'pills'
   end
 
@@ -196,12 +220,12 @@ format :html do
     end
     tab_panel tab_buttons, tab_panes, args[:tab_type]
   end
-  def default_tab_static_args args
+  def default_tabs_static_args args
     args[:tab_type] ||= 'tabs'
   end
 
   view :pills_static, :view=>:tabs
-  def default_tab_static_args args
+  def default_tabs_static_args args
     args[:tab_type] ||= 'pills'
   end
 

--- a/card/mod/01_core/spec/set/all/collection_spec.rb
+++ b/card/mod/01_core/spec/set/all/collection_spec.rb
@@ -94,6 +94,12 @@ describe Card::Set::All::Collection do
         assert_select "li > a[data-toggle=tab][data-url=#{path}]"
       end
     end
-
+    it 'handles nests as items' do
+      tabs = render_card :tabs, :name=>'tab_test', :type_id=>Card::PlainTextID, :content=>"{{A|type;title:my tab title}}"
+      assert_view_select tabs, 'div[role=tabpanel]' do
+        assert_select 'li > a[data-toggle=tab][href=#tab_test-a]', 'my tab title'
+        assert_select 'div.tab-pane#tab_test-a', 'Basic'
+      end
+    end
   end
 end

--- a/card/mod/02_basic_types/set/type/pointer.rb
+++ b/card/mod/02_basic_types/set/type/pointer.rb
@@ -283,6 +283,10 @@ def add_item name
     self.content="[[#{(item_names << name).reject(&:blank?)*"]]\n[["}]]"
   end
 end
+def add_item! name
+  add_item name
+  save!
+end
 
 def drop_item name
   if include_item? name
@@ -291,12 +295,20 @@ def drop_item name
     self.content = new_names.empty? ? '' : "[[#{new_names * "]]\n[["}]]"
   end
 end
+def drop_item! name
+  drop_item name
+  save!
+end
 
 def insert_item index, name
   new_names = item_names
   new_names.delete(name)
   new_names.insert(index,name)
   self.content =  new_names.map { |name| "[[#{name}]]" }.join "\n"
+end
+def insert_item! index, name
+  insert_item index, name
+  save!
 end
 
 


### PR DESCRIPTION
Example: the tabs view of a card with content 
````
{{A | labeled; title: tab A}}
{{B | titled; title: tab B}}
````
renders two tabs with the given titles as tab buttons and uses the given views for the tab panes.