### PR TITLE
remove non related source in groups

### DIFF
--- a/card/lib/card/simplecov_helper.rb
+++ b/card/lib/card/simplecov_helper.rb
@@ -1,3 +1,6 @@
+def is_in_mod? file,mod_path
+  file.src.join("") =~ /below pulled from #{Rails.root}\/mod/#{mod_path}\//
+end
 def card_simplecov_filters
   add_filter 'spec/'
   add_filter '/config/'
@@ -15,7 +18,8 @@ def card_simplecov_filters
       src_file.filename =~ /mod\/#{mod}\// or 
         (
           src_file.filename =~ /tmp\// and
-          /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/#{mod}/**/#{m[1].gsub("-","/")}"].present? } 
+          /\d+-(.+\.rb)/.match(src_file.filename) { |m| Dir["mod/#{mod}/**/#{m[1].gsub("-","/")}"].present? } and
+          is_in_mod? src_file,mod
         )
     end
   end


### PR DESCRIPTION
In coverage report, it always shows non mod code in mod groupings which may confused the readers.

I am not sure if this is a ok approach to check if the file is related to the mod. 