### PR TITLE
fix bug: cardio config overrides deck config

### DIFF
--- a/card/lib/cardio.rb
+++ b/card/lib/cardio.rb
@@ -28,30 +28,37 @@ module Cardio
       config.autoload_paths += Dir["#{gem_root}/lib/**/"]
       config.autoload_paths += Dir["#{root}/mod/*/lib/**/"]
 
-      config.read_only             = !!ENV['WAGN_READ_ONLY']
-      config.allow_inline_styles   = false
+      set_default_value config, :read_only,              !!ENV['WAGN_READ_ONLY']
+      set_default_value config, :allow_inline_styles,    false
 
-      config.recaptcha_public_key  = nil
-      config.recaptcha_private_key = nil
-      config.recaptcha_proxy       = nil
+      set_default_value config, :recaptcha_public_key,   nil
+      set_default_value config, :recaptcha_private_key,  nil
+      set_default_value config, :recaptcha_proxy,        nil
 
-      config.cache_store           = :file_store, 'tmp/cache'
-      config.override_host         = nil
-      config.override_protocol     = nil
+      set_default_value config, :cache_store,            :file_store, 'tmp/cache'
+      set_default_value config, :override_host,          nil
+      set_default_value config, :override_protocol,      nil
 
-      config.no_authentication     = false
-      config.files_web_path        = 'files'
+      set_default_value config, :no_authentication,      false
+      set_default_value config, :files_web_path,         'files'
 
-      config.max_char_count        = 200
-      config.max_depth             = 20
-      config.email_defaults        = nil
+      set_default_value config, :max_char_count,         200
+      set_default_value config, :max_depth,              20
+      set_default_value config, :email_defaults,         nil
 
-      config.token_expiry          = 2.days
-      config.revisions_per_page    = 10
-      config.space_last_in_multispace = true
-      config.closed_search_limit   = 50
+      set_default_value config, :token_expiry,           2.days
+      set_default_value config, :revisions_per_page,     10
+      set_default_value config, :space_last_in_multispace, true
+      set_default_value config, :closed_search_limit,    50
 
-      config.view_cache             = false
+      set_default_value config, :view_cache,             false
+    end
+
+    # In production mode set_config gets called twice.
+    # The second call overrides all deck config settings
+    # so don't change settings here if they already exist
+    def set_default_value config, setting, *value
+      config.send("#{setting}=", *value) unless config.respond_to? setting
     end
 
 


### PR DESCRIPTION
This problem occurs in Rails 4 but only in production mode. 
In production mode card/lib/cardio.rb#set_config gets called twice, in development only one time.
The second call overrides the deck configuration. I don't know why this is happening. This PR cures only the symptoms.