### PR TITLE
fix multiple editor on layout

### DIFF
--- a/card/mod/05_standard/set/all/rich_html/form.rb
+++ b/card/mod/05_standard/set/all/rich_html/form.rb
@@ -182,7 +182,7 @@ format :html do
 # FIELD VIEWS
 
   view :editor do |args|
-    text_area :content, :rows=>3, :class=>'tinymce-textarea card-content', :id=>unique_id, "data-card-type-code"=>card.type_code
+    text_area :content, :rows=>3, :class=>'tinymce-textarea card-content'
   end
 
   view :edit_in_form, :perms=>:update, :tags=>:unknown_ok do |args|

--- a/card/mod/05_standard/set/all/rich_html/form.rb
+++ b/card/mod/05_standard/set/all/rich_html/form.rb
@@ -182,7 +182,7 @@ format :html do
 # FIELD VIEWS
 
   view :editor do |args|
-    text_area :content, :rows=>3, :class=>'tinymce-textarea card-content'
+    text_area :content, :rows=>3, :class=>'tinymce-textarea card-content', :id=>unique_id
   end
 
   view :edit_in_form, :perms=>:update, :tags=>:unknown_ok do |args|

--- a/card/mod/05_standard/set/type/layout_type.rb
+++ b/card/mod/05_standard/set/type/layout_type.rb
@@ -3,12 +3,10 @@ include Html
 
 format do
   include Html::Format
-  view :editor do |args|
-    text_area :content, :rows=>5, :class=>'card-content ace-editor-textarea', "data-card-type-code"=>card.type_code
-  end
 end
 
 format :html do
+  include Html::HtmlFormat
   view :core do |args|
     with_inclusion_mode :template do
       process_content ::CodeRay.scan( _render_raw, :html ).div

--- a/card/mod/05_standard/set/type/layout_type.rb
+++ b/card/mod/05_standard/set/type/layout_type.rb
@@ -3,6 +3,9 @@ include Html
 
 format do
   include Html::Format
+  view :editor do |args|
+    text_area :content, :rows=>5, :class=>'card-content ace-editor-textarea', "data-card-type-code"=>card.type_code
+  end
 end
 
 format :html do


### PR DESCRIPTION
My theory is that, `layout_type.rb` is in 05_standard which gets the editor from `include Html::Format`. `html.rb` was in 05_standard as well but we moved it to 02_basic_types some days ago and therefore the editor is overridden in `rich_html/form.rb` in 05_standard. 

If this is the case, I just need to redefine the editor of ace editor for layout_type again and also remove the extra `data-card-type-code` property to trigger the ace editor as tinymce is defined in class already.