### PR TITLE
reorder the priority of js format in pointer

### DIFF
--- a/card/mod/02_basic_types/set/type/pointer.rb
+++ b/card/mod/02_basic_types/set/type/pointer.rb
@@ -197,7 +197,7 @@ end
 format :js do
   view :core do |args|
     card.item_cards.map do |item|
-      nest item, :view=>(params[:item] || args[:item] || :core)
+      nest item, :view=>( args[:item] || params[:item] || :core)
     end.join "\n\n"
   end
 end


### PR DESCRIPTION
Example: http://dev.wikirate.org/sebastian_jekutsch+csr_report_available+Acer_Inc_+2011+source?view=edit&slot[items][structure]=source_item&item=content&debug=script

```
nest item, :view=>(params[:item] || args[:item] || :core)
```
from `pointer.rb`
If `params[:item]` is in front of `args[:item]`, 
```
@js_tag = if params[:debug] == 'script'
      script_card.format(:js).render_core :item => :include_tag
    elsif script_card
      javascript_include_tag script_card.machine_output_url
    end
```
from `head.rb`
will render the content view for the items instead of view `:include_tag`.