### PR TITLE
fetch can now return trashed cards

### DIFF
--- a/card/mod/01_core/set/all/fetch.rb
+++ b/card/mod/01_core/set/all/fetch.rb
@@ -11,17 +11,17 @@ module ClassMethods
   #   - database
   #   - virtual cards
   #
-  # "mark" here means a generic identifier -- can be a numeric id, a name, a string name, etc.
+  # "mark" here means one of three unique identifiers
+  #    1. a numeric id (Integer)
+  #    2. a name/key (String or Card::Name)
+  #    3. a codename (Symbol)
   #
   #   Options:
   #     :skip_virtual               Real cards only
   #     :skip_modules               Don't load Set modules
+  #     :look_in_trash              Return trashed card objects
   #     :new => {  card opts }      Return a new card when not found
   #
-
-
-
-
   def fetch mark, opts={}
     if String === mark
       case mark
@@ -143,9 +143,13 @@ module ClassMethods
       val = mark
     end
 
-    card = send( "fetch_from_cache_by_#{mark_type}", val ) || begin
+    card = send( "fetch_from_cache_by_#{mark_type}", val )
+
+    if card.nil?
       needs_caching = true
-      send "find_by_#{mark_type}_and_trash", val, false
+      card = Card.where( mark_type => val, trash: false).take
+    elsif opts[:look_in_trash] && !card.trash
+      card = Card.where( mark_type => val ).take
     end
 
     [ card, mark, needs_caching ]

--- a/card/mod/01_core/set/all/fetch.rb
+++ b/card/mod/01_core/set/all/fetch.rb
@@ -145,11 +145,13 @@ module ClassMethods
 
     card = send( "fetch_from_cache_by_#{mark_type}", val )
 
-    if card.nil?
+    if opts[:look_in_trash]
+      if card.nil? || (card.new_card? && !card.trash)
+        card = Card.where( mark_type => val ).take
+      end
+    else
       needs_caching = true
       card = Card.where( mark_type => val, trash: false).take
-    elsif opts[:look_in_trash] && !card.trash
-      card = Card.where( mark_type => val ).take
     end
 
     [ card, mark, needs_caching ]

--- a/card/mod/01_core/set/all/states.rb
+++ b/card/mod/01_core/set/all/states.rb
@@ -1,5 +1,6 @@
 def new_card?
-  new_record? || !!@from_trash
+  new_record? ||   # not yet in db (from ActiveRecord)
+  !!@from_trash    # in process of restoration from trash, not yet "re-created"
 end
 alias_method :new?, :new_card?
 

--- a/card/mod/01_history/lib/card/action.rb
+++ b/card/mod/01_history/lib/card/action.rb
@@ -183,9 +183,9 @@ class Card
       end
     end
 
-#    def card
-#      Card.fetch card_id
-#    end
+    def card
+      Card.fetch card_id, look_in_trash: true
+    end
 
   end
 end

--- a/card/mod/01_history/set/all/history.rb
+++ b/card/mod/01_history/set/all/history.rb
@@ -96,7 +96,7 @@ end
 
 def current_rev_nr
   @current_rev_nr ||= begin
-    @intrusive_acts.first.actions.last.draft ? @intrusive_acts.size - 1 : @intrusive_acts.size
+    intrusive_acts.first.actions.last.draft ? @intrusive_acts.size - 1 : @intrusive_acts.size
   end
 end
 

--- a/card/mod/05_standard/spec/set/all/history_spec.rb
+++ b/card/mod/05_standard/spec/set/all/history_spec.rb
@@ -152,7 +152,7 @@ describe Card::Set::All::History do
           expect(act.card).to eq(@card)
         end
         it 'adds action for subcard' do
-          @card.update_attributes :subcards=>{"+right"=>{:content=>"New content", :content=>"New Content"}}
+          @card.update_attributes :subcards=>{"+right"=>{:content=>"New Content"}}
           act = @card.acts.last
           expect(act.actions.count).to eq(1)
           expect(act.actions.last.action_type).to eq(:update)

--- a/card/mod/05_standard/spec/set/type/image_spec.rb
+++ b/card/mod/05_standard/spec/set/type/image_spec.rb
@@ -15,7 +15,8 @@ describe Card::Set::Type::Image do
     assert_view_select rendered, 'img[src=?]', "/files/~#{image_card.id}/#{image_card.last_content_action_id}-small.jpg"
   end
 
-  context "new image card" do
+
+  context "newly created image card" do
     before do
       Card::Auth.as_bot do
         Card.create! :name => "image card", :type=>'image', :image=>File.new( File.join FIXTURES_PATH, 'mao2.jpg' )
@@ -58,6 +59,16 @@ describe Card::Set::Type::Image do
         expect(subject.format.render(:source)).to eq("/files/~#{subject.id}/#{subject.last_action_id}-medium.jpg")
       end
     end
+
+
+    describe 'view: act_expanded' do
+      it 'gets image url' do
+        act_summary = subject.format.render(:act_expanded, :act=>subject.last_act)
+        current_url = subject.image.versions[:medium].url
+        expect(act_summary).to match /#{Regexp.quote current_url}/
+      end
+    end
+
 
     context "updated file card" do
       before do


### PR DESCRIPTION
we need action.card to return a card (with set modules), even if it's in the trash.  In the long run, we probably want a lot of other trash handling, too.

What I've implemented so far is pretty unobtrusive; it really only changes things if you're fetching with :look_in_trash => true.  It basically bypasses the caching system.

Might want to look at using this mechanism when we actually retrieve from trash.