### PR TITLE
fix contextual name bug for references in WQL

### DIFF
--- a/card/card.gemspec
+++ b/card/card.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
     [ 'uuid',                       '~> 2.3'  ],
     [ 'carrierwave' ,               '~> 0.10' ],
     [ 'htmlentities',               '~> 4.3'  ],
-    [ 'mini_magick',                '~> 4.2'  ],
+    [ 'mini_magick',                '~> 4.2.10'  ],
     [ 'recaptcha',                  '~> 0.3'  ],
     [ 'coderay',                    '~> 1.0'  ],
     [ 'sass',                       '~> 3.2'  ],

--- a/card/lib/card/chunk.rb
+++ b/card/lib/card/chunk.rb
@@ -60,6 +60,8 @@ class Card
       attr_reader :text, :process_chunk
 
       class << self
+
+        # if the prefix regex matched check that chunk against the full regex
         def full_match content, prefix=nil
   #        warn "attempting full match on #{content}.  class = #{self}"
           content.match full_re( prefix )

--- a/card/mod/01_core/chunk/query_reference.rb
+++ b/card/mod/01_core/chunk/query_reference.rb
@@ -10,11 +10,12 @@ module Card::Chunk
   # 3a) {"plus_right":["Alfred"]}
   # but not in
   # 2b) "content":"foo", "Alfred":"bar"
-  # 3b) {"name":["Alfred", "Toni"]}
+  # 3b) {"name":["Alfred", "Toni"]}      ("Alfred" is an operator here)
   # It's not possible to distinguish between 2a) and 2b) or 3a) and 3b) with a simple regex
   # hence we use a too general regex and check for query keywords after the match
   # which of course means that we don't find references with query keywords as name
   class QueryReference < Reference
+
     QUERY_KEYWORDS = ::Set.new(
       (
         Card::Query::MODIFIERS.keys                +
@@ -26,15 +27,23 @@ module Card::Chunk
     )
     word = /\s*([^"]+)\s*/
 
-    # we check for colon, comma or square bracket before a quote
-    # OPTIMIZE: instead of comma or square bracket check for operator followed by comma or "plus_right"|"plus_left"|"plus" followed by square bracket
     Card::Chunk.register_class self, {
-      :prefix_re => '(?<=[:,\\[])\\s*"',  # we have to use a lookbehind, otherwise
-                                                  # if the colon matches it would be
-                                                  # identified mistakenly as an URI chunk
+      :prefix_re => '(?<=[:,\\[])\\s*"',  # we check for colon, comma or square bracket before a quote
+                                          # we have to use a lookbehind, otherwise
+                                          # if the colon matches it would be
+                                          # identified mistakenly as an URI chunk
       :full_re   => /"([^"]+)"/,
       :idx_char  => '"'
     }
+    # OPTIMIZE: instead of comma or square bracket check for operator followed by comma or "plus_right"|"plus_left"|"plus" followed by square bracket
+    # something like
+    # prefix_patterns = [
+    #     "\"\\s*(?:#{Card::Query::OPERATORS.keys.join('|')})\"\\s*,",
+    #     "\"\\s*(?:#{Card::Query::CardClause::PLUS_ATTRIBUTES}.keys.join('|')})\\s*:\\s*\\[\\s*",
+    #     "\"\\s*(?:#{(QUERY_KEYWORDS - Card::Query::CardClause::PLUS_ATTRIBUTES).join('|')})\"\\s*:",
+    #   ]
+    # :prefix_re => '(?<=#{prefix_patterns.join('|')})\\s*"'
+    # But: What do we do with the "in" operator? After the first value there is no prefix which we can use to detect the following values as QueryReference chunks
 
     class << self
       def full_match content, prefix
@@ -59,7 +68,7 @@ module Card::Chunk
 
     def replace_reference old_name, new_name
       replace_name_reference old_name, new_name
-      @text = "\"#{referee_name.to_s}\""
+      @text = "\"#{@name.to_s}\""
     end
   end
 end

--- a/card/mod/01_core/chunk/reference.rb
+++ b/card/mod/01_core/chunk/reference.rb
@@ -5,12 +5,12 @@ module Card::Chunk
 
     def referee_name
       return if name.nil?
-      
+
       @referee_name ||= begin
         rendered_name = render_obj( name )
         ref_card = case rendered_name
         when /^\~(\d+)$/ # get by id
-          Card.fetch $1.to_i 
+          Card.fetch $1.to_i
         when /^\:(\w+)$/ # get by codename
           Card.fetch $1.to_sym
         end
@@ -39,7 +39,7 @@ module Card::Chunk
         @name = name.to_name.replace_part( old_name, new_name )
       end
     end
-    
+
     def render_obj raw
       if format && Card::Content===raw
         format.card.references_expired = nil # don't love this; this is to keep from running update_references again

--- a/card/mod/05_standard/spec/chunk/include_spec.rb
+++ b/card/mod/05_standard/spec/chunk/include_spec.rb
@@ -7,16 +7,16 @@ describe Card::Chunk::Include, "Inclusion" do
       @class= Card::Chunk::Include
     end
 
-    it "should ignore invisible comments" do
+    it "ignores invisible comments" do
       expect(render_content("{{## now you see nothing}}")).to eq('')
     end
 
-    it "should handle visible comments" do
+    it "handles visible comments" do
       expect(render_content("{{# now you see me}}")).to eq('<!-- # now you see me -->')
       expect(render_content("{{# -->}}")).to eq('<!-- # --&gt; -->')
     end
 
-    it "should handle empty inclusions" do
+    it "handles empty inclusions" do
       instance = @class.new( @class.full_match( '{{ }}' ) , nil )
       expect(instance.name).to eq('')
       expect(instance.options[:inc_syntax]).to eq(' ')
@@ -26,25 +26,25 @@ describe Card::Chunk::Include, "Inclusion" do
 
     end
 
-    it "should handle no pipes" do
+    it "handles no pipes" do
       instance = @class.new( @class.full_match( '{{toy}}') , nil )
       expect(instance.name).to eq('toy')
       expect(instance.options[:inc_name]).to eq('toy')
       expect(instance.options.key?(:view)).to eq(false)
     end
 
-    it "should strip the name" do
+    it "strips the name" do
       expect(@class.new( @class.full_match( '{{ toy }}') , nil ).name).to eq('toy')
     end
 
-    it 'should strip html tags' do
+    it 'strips html tags' do
       expect(@class.new( @class.full_match( '{{ <span>toy</span> }}') , nil ).name).to eq('toy')
       instance = @class.new( @class.full_match( '{{ <span>toy|open</span> }}') , nil )
       expect(instance.name).to eq('toy')
       expect(instance.options[:view]).to eq('open')
     end
 
-    it "should handle single pipe" do
+    it "handles single pipe" do
       options = @class.new( @class.full_match('{{toy|view:link;hide:me}}'), nil ).options
       expect(options[:inc_name]).to eq('toy')
       expect(options[:view]).to eq('link')
@@ -52,7 +52,7 @@ describe Card::Chunk::Include, "Inclusion" do
       expect(options.key?(:items)).to eq(false)
     end
 
-    it "should handle multiple pipes" do
+    it "handles multiple pipes" do
       options = @class.new( @class.full_match('{{box|open|closed}}'), nil ).options
       expect(options[:inc_name]).to eq('box')
       expect(options[:view]).to eq('open')
@@ -60,31 +60,36 @@ describe Card::Chunk::Include, "Inclusion" do
       expect(options[:items].key?(:items)).to eq(false)
     end
 
-    it "should handle multiple pipes with blank lists" do
+    it "handles multiple pipes with blank lists" do
       options = @class.new( @class.full_match('{{box||closed}}'), nil ).options
       expect(options[:inc_name]).to eq('box')
       expect(options[:view]).to eq(nil)
       expect(options[:items][:view]).to eq('closed')
     end
 
-    it "should treat :item as view of next level" do
+    it "treats :item as view of next level" do
       options = @class.new( @class.full_match('{{toy|link;item:name}}'), nil ).options
       expect(options[:inc_name]).to eq('toy')
       expect(options[:view]).to eq('link')
       expect(options[:items][:view]).to eq('name')
     end
+
+    it "handles contextual names" do
+      instance = @class.new( @class.full_match( '{"name":"_+toy"}') , nil )
+      expect(instance.name).to eq('toy')
+    end
   end
 
   context "rendering" do
 
-    it "should handle absolute names" do
+    it "handles absolute names" do
       alpha = newcard 'Alpha', "Pooey"
       beta = newcard 'Beta', "{{Alpha}}"
       result = beta.format.render_core
       assert_view_select result, 'div[class~="card-content"]', "Pooey"
     end
 
-    it "should handle simple relative names" do
+    it "handles simple relative names" do
       alpha = newcard 'Alpha', "{{#{Card::Name.joint}Beta}}"
       beta = newcard 'Beta'
       alpha_beta = Card.create :name=>"#{alpha.name}#{Card::Name.joint}Beta", :content=>"Woot"

--- a/card/mod/05_standard/spec/chunk/include_spec.rb
+++ b/card/mod/05_standard/spec/chunk/include_spec.rb
@@ -74,10 +74,6 @@ describe Card::Chunk::Include, "Inclusion" do
       expect(options[:items][:view]).to eq('name')
     end
 
-    it "handles contextual names" do
-      instance = @class.new( @class.full_match( '{"name":"_+toy"}') , nil )
-      expect(instance.name).to eq('toy')
-    end
   end
 
   context "rendering" do

--- a/card/mod/05_standard/spec/chunk/query_reference_spec.rb
+++ b/card/mod/05_standard/spec/chunk/query_reference_spec.rb
@@ -1,0 +1,50 @@
+# -*- encoding : utf-8 -*-
+
+describe Card::Chunk::QueryReference, "QueryReference" do
+
+  context "syntax parsing" do
+    before do
+      @class= Card::Chunk::QueryReference
+    end
+
+    let :query_refs do
+       content = Card::Content.new @content, Card.new(:type=>'Search')
+       content.find_chunks(Card::Chunk::QueryReference)
+    end
+
+    subject { query_refs.first.name }
+
+    it "handles simple search" do
+      @content = '{"name":"Waldo"}'
+      is_expected.to eq 'Waldo'
+    end
+
+    it "handles operators" do
+      @content = '{"name":["eq","Waldo"]}'
+      is_expected.to eq 'Waldo'
+    end
+
+    it "handles multiple values for operators" do
+      @content = '{"name":["in","Where","Waldo"]}'
+      expect(query_refs[1].name).to eq 'Waldo'
+    end
+
+    it "handles plus attributes" do
+      @content = '{"right_plus":["Waldo",{"content":"here"}]}'
+      is_expected.to eq  'Waldo'
+    end
+
+    it "handles nested query structures" do
+      @content = '{"any":{"content":"Where", "right_plus":["is",{"name":"Waldo"}]}}'
+      expect(query_refs[0].name).to eq 'Where'
+      expect(query_refs[1].name).to eq 'is'
+      expect(query_refs[2].name).to eq 'Waldo'
+    end
+
+    it "handles contextual names" do
+      @content =  '{"name":"_+Waldo"}'
+      is_expected.to eq '_+Waldo'
+    end
+  end
+
+end

--- a/card/spec/lib/card/reference_spec.rb
+++ b/card/spec/lib/card/reference_spec.rb
@@ -169,6 +169,20 @@ describe Card::Reference do
     expect(Card['search with references'].referees.map(&:name).sort).to eq ["A","B","X","Y"]
   end
 
+  it "handles contextual names in Basic cards" do
+    card = Card.create :type=>'Basic', :name=>'basic with references',
+      :content=>'{{_+A}}'
+    Card['A'].update_attributes! :name=>'AAA', :update_referencers=>true
+    expect(Card['basic with references'].content).to eq '{{_+AAA}}'
+  end
+
+  it "handles contextual names in Search cards" do
+    card = Card.create :type=>'Search', :name=>'search with references',
+      :content=>'{"name":"_+A"}'
+    Card['A'].update_attributes! :name=>'AAA', :update_referencers=>true
+    expect(Card['search with references'].content).to eq '{"name":"_+AAA"}'
+  end
+
   it "should handle commented inclusion" do
     c = Card.create :name=>'inclusion comment test', :content=>'{{## hi mom }}'
     expect(c.errors.any?).to be_falsey


### PR DESCRIPTION
Solves the following problem:
If you have a search card "Waldo+\*right+\*structure" with content `{"found_by":"_+Me"}` and you rename "Me" to "You" then the content of "Waldo+*right+*structure" changes to `{"found_by":"Waldo+\*right+\*structure+You"}`