### PR TITLE
Queryclean

### DIFF
--- a/card/lib/card/query/attributes.rb
+++ b/card/lib/card/query/attributes.rb
@@ -28,16 +28,30 @@ class Card
       end
 
       def editor_of val
-        acts_alias, actions_alias = "a#{table_id force=true}", "an#{table_id force=true}"
-        joins <<  Join.new( from: self, to: ['card_acts', acts_alias, 'actor_id' ] )
-        joins <<  Join.new( from: ['card_acts', acts_alias], to: ['card_actions', actions_alias, 'card_act_id'] )
+        acts_alias, actions_alias =
+          "a#{table_id force=true}", "an#{table_id force=true}"
+        joins << Join.new(
+          from: self,
+          to: ['card_acts', acts_alias, 'actor_id' ]
+        )
+        joins << Join.new(
+          from: ['card_acts', acts_alias],
+          to: ['card_actions', actions_alias, 'card_act_id']
+        )
         join_cards val, from_alias: actions_alias, from_field: 'card_id'
       end
 
       def edited_by val
-        acts_alias, actions_alias = "a#{table_id force=true}", "an#{table_id force=true}"
-        joins <<  Join.new( from: self, to: ['card_actions', actions_alias, 'card_id' ] )
-        joins <<  Join.new( from: ['card_actions', actions_alias, 'card_act_id' ], to: ['card_acts', acts_alias] )
+        acts_alias, actions_alias =
+          "a#{table_id force=true}", "an#{table_id force=true}"
+        joins << Join.new(
+          from: self,
+          to: ['card_actions', actions_alias, 'card_id' ]
+        )
+        joins << Join.new(
+          from: ['card_actions', actions_alias, 'card_act_id' ],
+          to: ['card_acts', acts_alias]
+        )
         join_cards val, from_alias: acts_alias, from_field: 'actor_id'
       end
 
@@ -91,23 +105,33 @@ class Card
 
 
       def found_by val
-
-        cards = if Hash===val
-          Query.new(val).run
-        else
-          Array.wrap(val).map do |v|
-            Card.fetch val.to_name.to_absolute(root.context), :new=>{}
+        #binding.pry
+        found_by_cards(val).compact.each do |c|
+          if c && [SearchTypeID, SetID].include?(c.type_id)
+            #FIXME - move this check to set mods!
+            statement = c.get_query.symbolize_keys.merge(
+              return: :condition, context: c.name
+            )
+            sq = subquery statement
+          else
+            raise BadQuery,
+              '"found_by" value must be valid Search, ' +
+              "but #{c.name} is a #{c.type_name}"
           end
-        end
-
-        cards.each do |c|
-          unless c && [SearchTypeID,SetID].include?(c.type_id)
-            raise BadQuery, %{"found_by" value needs to be valid Search, but #{c.name} is a #{c.type_name}}
-          end
-          interpret Query.new(c.get_query).statement
         end
       end
 
+
+      def found_by_cards val
+        if Hash===val
+          Query.run val
+        else
+          Array.wrap(val).map do |v|
+            Card.fetch val.to_name.to_absolute(context), :new=>{}
+          end
+        end
+
+      end
 
       def match(val)
         cxn, val = match_prep val
@@ -115,7 +139,10 @@ class Card
         return nil if val.strip.empty?
 
         val_list = val.split(/\s+/).map do |v|
-          name_or_content = ["replace(#{self.table_alias}.name,'+',' ')","#{self.table_alias}.db_content"].map do |field|
+          name_or_content = [
+            "replace(#{self.table_alias}.name,'+',' ')",
+            "#{self.table_alias}.db_content"
+          ].map do |field|
             %{#{field} #{ cxn.match quote("[[:<:]]#{v}[[:>:]]") }}
           end
           "(#{name_or_content.join ' OR '})"
@@ -125,8 +152,13 @@ class Card
 
 
       def complete(val)
-        no_plus_card = (val=~/\+/ ? '' : "and right_id is null")  #FIXME -- this should really be more nuanced -- it breaks down after one plus
-        add_condition " lower(name) LIKE lower(#{quote(val.to_s+'%')}) #{no_plus_card}"
+        no_plus_card = (val =~ /\+/ ? '' : "and right_id is null")
+        # FIXME -- this should really be more nuanced --
+        # it breaks down after one plus
+
+        add_condition(
+          " lower(name) LIKE lower(#{quote(val.to_s+'%')}) #{no_plus_card}"
+        )
       end
 
       def extension_type val
@@ -144,11 +176,15 @@ class Card
         joins << Join.new(:from=>self, :to=>r, :to_field=>r.infield)
         s = nil
         if r.cardquery
-          s = join_cards r.cardquery, from_alias: r.table_alias, from_field: r.outfield
+          s = join_cards r.cardquery,
+            from_alias: r.table_alias,
+            from_field: r.outfield
         end
         if r.conditions.any?
           s ||= subquery
-          s.add_condition r.conditions.map { |condition| "#{r.table_alias}.#{condition}" } * ' AND '
+          s.add_condition( r.conditions.map do |condition|
+            "#{r.table_alias}.#{condition}"
+          end * ' AND ')
         end
       end
 
@@ -166,30 +202,50 @@ class Card
         if sort_field == 'count'
           sort_by_count val, item
         else
-          join_field = SORT_JOIN_TO_ITEM_MAP[item.to_sym] or raise BadQuery, "sort item: #{item} not yet implemented"
-          sq = join_cards val, to_field: join_field, side: 'LEFT', conditions_on_join: true
-          @mods[:sort] ||= "#{sq.table_alias}.#{sort_field}"
+          if join_field = SORT_JOIN_TO_ITEM_MAP[item.to_sym]
+            sq = join_cards val,
+              to_field: join_field,
+              side: 'LEFT',
+              conditions_on_join: true
+            @mods[:sort] ||= "#{sq.table_alias}.#{sort_field}"
+          else
+            raise BadQuery, "sort item: #{item} not yet implemented"
+          end
         end
 
       end
 
       # EXPERIMENTAL!
       def sort_by_count val, item
-        raise BadQuery, "count with item: #{item} not yet implemented" unless item == 'referred_to'
-        @mods[:sort] = "coalesce(count,0)" # needed for postgres
-        cs = Query.new :return=>'count', :group=>'sort_join_field', :superquery=>self
-        cs.add_condition "referer_id in (#{Query.new( val.merge(return: 'id', superquery: self)).sql})"
-        # FIXME - SQL generated before SQL phase
-        cs.joins << Join.new(from: cs, to:['card_references', 'wr', 'referee_id'])
-        cs.mods[:sort_join_field] = "#{cs.table_alias}.id as sort_join_field" #HACK!
-        @joins << Join.new( from: self, to: [cs, 'srtbl', 'sort_join_field'] )
+        if item == 'referred_to'
+          @mods[:sort] = "coalesce(count,0)" # needed for postgres
+          cs = Query.new(
+            :return=>'count',
+            :group=>'sort_join_field',
+            :superquery=>self
+          )
+          subselect = Query.new(val.merge return: 'id', superquery: self)
+          cs.add_condition "referer_id in (#{subselect.sql})"
+          # FIXME - SQL generated before SQL phase
+          cs.joins << Join.new(
+            from: cs,
+            to:['card_references', 'wr', 'referee_id']
+          )
+          cs.mods[:sort_join_field] = "#{cs.table_alias}.id as sort_join_field"
+          #HACK!
+
+          @joins << Join.new(
+            from: self,
+            to: [cs, 'srtbl', 'sort_join_field']
+          )
+        else
+          raise BadQuery, "count with item: #{item} not yet implemented"
+        end
       end
-
-
 
       def table_alias
         @table_alias ||= begin
-          if @mods[:return]=='condition' && @superquery
+          if @statement[:return] == :condition && @superquery
             @superquery.table_alias
           else
             "c#{table_id}"
@@ -233,7 +289,7 @@ class Card
       alias :in :any
 
       def conjoin val, conj
-        sq = subquery( :return=>:condition, :conj=>conj )
+        sq = subquery( return: :condition, conj: conj )
         unless Array===val
           val = clause_to_hash(val).map { |key, value| { key => value } }
         end
@@ -243,9 +299,14 @@ class Card
       end
 
       def not val
-        subselect = Query.new clause_to_hash(val).merge( :return=>:id )
+        subselect = Query.new clause_to_hash(val).merge( return: :id )
         join_alias = "not#{table_id force=true}"
-        @joins << Join.new( from: self, to_table: subselect, to_alias: join_alias, :side=>'LEFT' )
+        @joins << Join.new(
+          from: self,
+          to_table: subselect,
+          to_alias: join_alias,
+          side: 'LEFT'
+        )
         add_condition "#{join_alias}.id is null"
       end
 

--- a/card/lib/card/query/sql_statement.rb
+++ b/card/lib/card/query/sql_statement.rb
@@ -119,8 +119,8 @@ class Card
         full_syntax do
           limit, offset = @mods[:limit], @mods[:offset]
           if limit.to_i > 0
-            string =  "LIMIT  #{ limit.to_i  }"
-            string += "OFFSET #{ offset.to_i }" if offset.present?
+            string =  "LIMIT  #{ limit.to_i  } "
+            string += "OFFSET #{ offset.to_i } " if offset.present?
             string
           end
         end

--- a/card/lib/cardio.rb
+++ b/card/lib/cardio.rb
@@ -8,7 +8,7 @@ module Cardio
   CARD_GEM_ROOT = File.expand_path('../..', __FILE__)
 
   ActiveSupport.on_load :card do
-    if Card.count > 0
+    if Card.take
       Card::Loader.load_mods
     else
       Rails.logger.warn "empty database"

--- a/card/mod/01_core/set/all/collection.rb
+++ b/card/mod/01_core/set/all/collection.rb
@@ -1,12 +1,7 @@
 
 module ClassMethods
-  def search spec, &block
-    query = ::Card::Query.new(spec)
-    execute_query query, &block
-  end
-
-  def execute_query query
-    results = query.run
+  def search spec
+    results = ::Card::Query.run(spec)
     if block_given? and Array===results
       results.each { |result| yield result }
     end

--- a/card/mod/01_core/set/all/templating.rb
+++ b/card/mod/01_core/set/all/templating.rb
@@ -62,7 +62,7 @@ end
 def structuree_names
   if wql = structuree_spec
     Auth.as_bot do
-      Card::Query.new(wql.merge return: :name).run
+      Card::Query.run(wql.merge return: :name)
     end
   else
     []
@@ -84,7 +84,8 @@ def update_structurees args
   # by a +*type plus right+*structure rule, the override would not be respected.
   if query = structuree_spec
     Auth.as_bot do
-      Card::Query.new( query.merge(return: :id) ).run.each_slice(100) do |id_batch|
+      query[:return] = :id
+      Card::Query.run(query).each_slice(100) do |id_batch|
         Card.where( id: id_batch ).update_all args
       end
     end

--- a/card/mod/02_basic_types/set/type/pointer.rb
+++ b/card/mod/02_basic_types/set/type/pointer.rb
@@ -235,8 +235,8 @@ end
 
 def item_cards args={}
   if args[:complete]
-    #warn "item_card[#{args.inspect}], :complete"
-    Card::Query.new({referred_to_by: name}.merge(args)).run
+    query = { referred_to_by: name }.merge args
+    Card::Query.run query
   else
 
     itype = args[:type] || item_type

--- a/card/mod/05_standard/set/type/search_type.rb
+++ b/card/mod/05_standard/set/type/search_type.rb
@@ -28,8 +28,10 @@ end
 def get_query params={}
   query = Auth.as_bot do ## why is this a wagn_bot thing?  can't deny search content??
     query_content = params.delete(:query) || raw_content
-    #warn "get_query #{name}, #{query_content}, #{params.inspect}"
-    raise(JSON::ParserError, "Error in card '#{self.name}':can't run search with empty content") if query_content.empty?
+    if query_content.empty?
+      raise JSON::ParserError,
+        "Error in card '#{self.name}':can't run search with empty content"
+    end
     String === query_content ? JSON.parse( query_content ) : query_content
   end
   query.symbolize_keys!.merge! params.symbolize_keys

--- a/card/spec/lib/card/query_spec.rb
+++ b/card/spec/lib/card/query_spec.rb
@@ -316,15 +316,51 @@ describe Card::Query do
       )
     end
 
-    it("should handle link_to")       { expect(Card::Query.new( link_to: 'Z').run.map(&:name)).to eq(%w{ A }) }
-    it("should handle include" )      { expect(Card::Query.new( include: 'Z').run.map(&:name)).to eq(%w{ B }) }
-    it("should handle linked_to_by")   { expect(Card::Query.new( linked_to_by: 'A').run.map(&:name)).to eq(%w{ Z }) }
-    it("should handle included_by")    { expect(Card::Query.new( included_by: 'B').run.map(&:name)).to eq(%w{ Z }) }
-    it("should handle referred_to_by") { expect(Card::Query.new( referred_to_by: 'X').run.map(&:name).sort).to eq(%w{ A A+B T }) }
+    it "should handle link_to" do
+      expect(Card::Query.run(
+        link_to: 'Z'
+      ).map(&:name)).to eq(
+        %w{ A }
+      )
+    end
+
+    it "should handle include" do
+      expect(Card::Query.run(
+        include: 'Z'
+      ).map(&:name)).to eq(
+        %w{ B }
+      )
+    end
+
+    it "should handle linked_to_by" do
+      expect(Card::Query.run(
+        linked_to_by: 'A'
+      ).map(&:name)).to eq(
+        %w{ Z }
+      )
+    end
+
+    it "should handle included_by" do
+      expect(Card::Query.run(
+        included_by: 'B'
+      ).map(&:name)).to eq(
+        %w{ Z }
+      )
+    end
+
+    it "should handle referred_to_by" do
+      expect(Card::Query.run(
+        referred_to_by: 'X'
+      ).map(&:name).sort).to eq(
+        %w{ A A+B T }
+      )
+    end
   end
 
   describe "relative links" do
-    it("should handle relative refer_to")  { expect(Card::Query.new( refer_to: '_self', context: 'Z').run.map(&:name).sort).to eq(%w{ A B }) }
+    it("should handle relative refer_to")  { expect(Card::Query.run(
+      refer_to: '_self', context: 'Z'
+      ).map(&:name).sort).to eq(%w{ A B }) }
   end
 
   describe "permissions" do
@@ -332,102 +368,162 @@ describe Card::Query do
       Card::Auth.as_bot  do
         Card.create name: "C+*self+*read", type: 'Pointer', content: "[[R1]]"
       end
-      expect(Card::Query.new( plus: "A" ).run.map(&:name).sort).to eq(%w{ B D E F })
+      expect(Card::Query.run(
+        plus: "A"
+      ).map(&:name).sort).to eq(
+        %w{ B D E F }
+      )
     end
   end
 
   describe "basics" do
     it "should be case insensitive for name" do
-      expect(Card::Query.new( name: "a" ).run.first.name).to eq('A')
+      expect(Card::Query.run(
+        name: "a"
+      ).first.name).to eq(
+        'A'
+      )
     end
 
     it "should find plus cards" do
-      expect(Card::Query.new( plus: "A" ).run.map(&:name).sort).to eq(A_JOINEES)
+      expect(Card::Query.run(
+        plus: "A"
+      ).map(&:name).sort).to eq(
+        A_JOINEES
+      )
     end
 
     it "should find connection cards" do
-      expect(Card::Query.new( part: "A" ).run.map(&:name).sort).to eq(["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"])
+      expect(Card::Query.run(
+        part: "A"
+      ).map(&:name).sort).to eq(
+        ["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"]
+      )
     end
 
     it "should find left connection cards" do
-      expect(Card::Query.new( left: "A" ).run.map(&:name).sort).to eq(["A+B", "A+C", "A+D", "A+E"])
+      expect(Card::Query.run(
+      left: "A"
+      ).map(&:name).sort).to eq(["A+B", "A+C", "A+D", "A+E"])
     end
 
     it "should find right connection cards" do
       [ { right: "A"},                         # query by name
         { right: { content: "Alpha [[Z]]" } }  # query by content
       ].each do |statement|
-        expect(Card::Query.new( statement ).run.map(&:name).sort).to eq(["C+A", "D+A", "F+A"])
+        expect(Card::Query.run(
+      statement
+      ).map(&:name).sort).to eq(["C+A", "D+A", "F+A"])
       end
     end
 
     it "should return count" do
       expect(Card.count_by_wql( part: "A" )).to eq(7)
     end
-
-
   end
 
   describe "limit and offset" do
     it "should return limit" do
-      expect(Card::Query.new( part: "A", limit: 5 ).run.size).to eq(5)
+      expect(Card::Query.run(
+      part: "A", limit: 5
+      ).size).to eq(5)
     end
 
     it "should not break if offset but no limit" do
-      expect(Card::Query.new( part: "A", offset: 5 ).run.size).not_to eq(0)
+      expect(Card::Query.run(
+      part: "A", offset: 5
+      ).size).not_to eq(0)
     end
 
   end
 
   describe "type" do
-    user_cards =  ["Big Brother", "Joe Admin", "Joe Camel", "Joe User", "John", "Narcissist", "No Count", "Optic fan", "Sample User", "Sara", "Sunglasses fan", "u1", "u2", "u3"].sort
+    user_cards = [
+      "Big Brother", "Joe Admin", "Joe Camel", "Joe User", "John",
+      "Narcissist", "No Count", "Optic fan", "Sample User", "Sara",
+      "Sunglasses fan", "u1", "u2", "u3"
+    ].sort
 
     it "should find cards of this type" do
-      expect(Card::Query.new( type: "_self", context: 'User').run.map(&:name).sort).to eq(user_cards)
+      expect(Card::Query.run(
+        type: "_self", context: 'User'
+      ).map(&:name).sort).to eq(
+        user_cards
+      )
     end
 
     it "should find User cards " do
-      expect(Card::Query.new( type: "User" ).run.map(&:name).sort).to eq(user_cards)
+      expect(Card::Query.run(
+        type: "User"
+      ).map(&:name).sort).to eq(
+        user_cards
+      )
     end
 
     it "should handle casespace variants" do
-      expect(Card::Query.new( type: "users" ).run.map(&:name).sort).to eq(user_cards)
+      expect(Card::Query.run(
+        type: "users"
+      ).map(&:name).sort).to eq(
+        user_cards
+      )
     end
-
   end
-
 
   describe "trash handling" do
     it "should not find cards in the trash" do
       Card["A+B"].delete!
-      expect(Card::Query.new( left: "A" ).run.map(&:name).sort).to eq(["A+C", "A+D", "A+E"])
+      expect(Card::Query.run(
+        left: "A"
+      ).map(&:name).sort).to eq(
+        ["A+C", "A+D", "A+E"]
+      )
     end
   end
-
-
-
 
   describe "order" do
     it "should sort by create" do
       Card.create! name: "classic bootstrap skin head"
-      # classic skin head is created more recently than classic skin, which is in the seed data
-      wql = { sort: "create", name: [:match,'classic bootstrap skin']}
-      expect( Card::Query.new(wql).run.map(&:name) ).to eq( ["classic bootstrap skin","classic bootstrap skin head"] )
+      # classic skin head is created more recently than classic skin,
+      # which is in the seed data
+      expect( Card::Query.run(
+        sort: "create", name: [:match,'classic bootstrap skin']
+      ).map(&:name) ).to eq(
+        ["classic bootstrap skin","classic bootstrap skin head"]
+      )
     end
 
     it "should sort by name" do
-      expect(Card::Query.new( name: %w{ in B Z A Y C X }, sort: "alpha", dir: "desc" ).run.map(&:name)).to eq(%w{ Z Y X C B A })
-      expect(Card::Query.new( name: %w{ in B Z A Y C X }, sort: "name", dir: "desc"  ).run.map(&:name)).to eq(%w{ Z Y X C B A })
+      expect(Card::Query.run(
+        name: %w{ in B Z A Y C X }, sort: "alpha", dir: "desc"
+      ).map(&:name)).to eq(
+        %w{ Z Y X C B A }
+      )
+
+      expect(Card::Query.run(
+        name: %w{ in B Z A Y C X }, sort: "name", dir: "desc"
+      ).map(&:name)).to eq(
+        %w{ Z Y X C B A }
+      )
       #Card.create! name: 'the alphabet'
-      #Card::Query.new( name: ["in", "B", "C", "the alphabet"], sort: "name").run.map(&:name).should ==  ["the alphabet", "B", "C"]
+      #Card::Query.run(
+      #name: ["in", "B", "C", "the alphabet"], sort: "name"
+      #).map(&:name).should ==  ["the alphabet", "B", "C"]
     end
 
     it "should sort by content" do
-      expect(Card::Query.new( name: %w{ in Z T A }, sort: "content").run.map(&:name)).to eq(%w{ A Z T })
+      expect(Card::Query.run(
+        name: %w{ in Z T A }, sort: "content"
+      ).map(&:name)).to eq(
+        %w{ A Z T }
+      )
     end
 
     it "should play nice with match" do
-      expect(Card::Query.new( match: 'Z', type: 'Basic', sort: "content").run.map(&:name)).to eq(%w{ A B Z })
+      expect(Card::Query.run(
+        match: 'Z', type: 'Basic', sort: "content"
+      ).map(&:name)).to eq(
+        %w{ A B Z }
+      )
     end
 
     it "should sort by plus card content" do
@@ -437,24 +533,35 @@ describe Card::Query do
         c.save
         c = Card.create! name: 'Basic+*type+*table of contents', content: '3'
 
-        w = Card::Query.new( right_plus: '*table of contents', sort: { right: '*table_of_contents'}, sort_as: 'integer'  )
-        #warn "sql from new wql = #{w.sql}"
-        expect(w.run.map(&:name)).to eq(%w{ *all Basic+*type Setting+*self })
+        expect(Card::Query.run(
+          right_plus: '*table of contents',
+          sort: { right: '*table_of_contents'}, sort_as: 'integer'
+        ).map(&:name)).to eq(
+          %w{ *all Basic+*type Setting+*self }
+        )
       end
     end
 
     it "should sort by count" do
       Card::Auth.as_bot do
-        w = Card::Query.new( name: [:in,'*always','*never','*edited'], sort: { right: '*follow', item: 'referred_to', return: 'count' } )
-        expect(w.run.map(&:name)).to eq(['*never','*edited','*always'])
+        expect(Card::Query.run(
+          name: [:in,'*always', '*never', '*edited'],
+          sort: { right: '*follow', item: 'referred_to', return: 'count' }
+        ).map(&:name)).to eq(
+          ['*never', '*edited', '*always']
+        )
       end
     end
 
   #  it "should sort by update" do
   #    # do this on a restricted set so it won't change every time we add a card..
-  #    Card::Query.new( match: "two", sort: "update", dir: "desc").run.map(&:name).should == ["One+Two+Three", "One+Two","Two","Joe User"]
+  #    Card::Query.run(
+  #    match: "two", sort: "update", dir: "desc"
+  #    ).map(&:name).should == ["One+Two+Three", "One+Two","Two","Joe User"]
   #    Card["Two"].update_attributes! content: "new bar"
-  #    Card::Query.new( match: "two", sort: "update", dir: "desc").run.map(&:name).should == ["Two","One+Two+Three", "One+Two","Joe User"]
+  #    Card::Query.run(
+  #    match: "two", sort: "update", dir: "desc"
+  #    ).map(&:name).should == ["Two","One+Two+Three", "One+Two","Joe User"]
   #  end
   #
 
@@ -462,42 +569,84 @@ describe Card::Query do
 
   describe "match" do
     it "should reach content and name via shortcut" do
-      expect(Card::Query.new( match: "two").run.map(&:name).sort).to eq(CARDS_MATCHING_TWO)
+      expect(Card::Query.run(
+        match: "two"
+      ).map(&:name).sort).to eq(
+        CARDS_MATCHING_TWO
+      )
     end
 
     it "should get only content when content is explicit" do
-      expect(Card::Query.new( content: [:match, "two"] ).run.map(&:name).sort).to eq(["Joe User"])
+      expect(Card::Query.run(
+        content: [:match, "two"]
+      ).map(&:name).sort).to eq(
+        ["Joe User"]
+      )
     end
 
     it "should get only name when name is explicit" do
-      expect(Card::Query.new( name: [:match, "two"] ).run.map(&:name).sort).to eq(["One+Two","One+Two+Three","Two"].sort)
+      expect(Card::Query.run(
+        name: [:match, "two"]
+      ).map(&:name).sort).to eq(
+        ["One+Two","One+Two+Three","Two"].sort
+      )
     end
   end
 
   describe "and" do
     it "should act as a simple passthrough" do
-      expect(Card::Query.new(and: {match: 'two'}).run.map(&:name).sort).to eq(CARDS_MATCHING_TWO)
-      expect(Card::Query.new(and: {}, type: "Cardtype E").run.first.name).to eq('type-e-card')
+      expect(Card::Query.run(
+        and: { match: 'two' }
+      ).map(&:name).sort).to eq(
+        CARDS_MATCHING_TWO
+      )
+
+      expect(Card::Query.run(
+        and: {}, type: "Cardtype E"
+      ).first.name).to eq(
+        'type-e-card'
+      )
     end
 
     it "should work within 'or'" do
-      results = Card::Query.new(or: {name: 'Z', and: {left: 'A', right: 'C'}}).run
-      expect(results.length).to eq(2)
-      expect(results.map(&:name).sort).to eq(['A+C','Z'])
+      expect(Card::Query.run(
+        or: { name: 'Z', and: { left: 'A', right: 'C' } },
+        return: :name, sort: :name
+      )).to eq(
+        ['A+C','Z']
+      )
     end
   end
 
   describe "any/or" do
     it "should work with :plus" do
-      expect(Card::Query.new(plus: "A", or: {name: 'B', match: 'K'}, return: 'name').run.sort).to eq(%w{ B })
-      expect(Card::Query.new(plus: "A", any: {name: 'B', match: 'K'}, return: 'name').run.sort).to eq(%w{ B })
-      expect(Card::Query.new(or: {right_plus: "A", plus: 'B'}, return: 'name').run.sort).to eq(%w{ A C D F })
+      expect(Card::Query.run(
+        plus: "A", or: { name: 'B', match: 'K' }, return: :name, sort: :name
+      )).to eq(
+        %w{ B }
+      )
+
+      expect(Card::Query.run(
+        plus: "A", any: { name: 'B', match: 'K'}, return: :name, sort: :name
+      )).to eq(
+        %w{ B }
+      )
+
+      expect(Card::Query.run(
+        or: { right_plus: "A", plus: 'B' }, return: :name, sort: :name
+      )).to eq(
+        %w{ A C D F }
+      )
     end
   end
 
   describe "offset" do
     it "should not break count" do
-      expect(Card.count_by_wql({match: 'two', offset: 1})).to eq(CARDS_MATCHING_TWO.length)
+      expect(Card.count_by_wql(
+        match: 'two', offset: 1
+      )).to eq(
+        CARDS_MATCHING_TWO.length
+      )
     end
   end
 
@@ -506,36 +655,39 @@ describe Card::Query do
   describe "found_by" do
     before do
       Card::Auth.current_id = Card::WagnBotID
-      c = Card.create(name: 'Simple Search', type: 'Search', content: '{"name":"A"}')
+      c = Card.create(
+        name: 'Simple Search', type: 'Search', content: '{"name":"A"}'
+      )
     end
 
     it "should find cards returned by search of given name" do
-      expect(Card::Query.new(
+      expect(Card::Query.run(
         found_by: 'Simple Search'
-      ).run.first.name).to eq('A')
+      ).first.name).to eq(
+        'A'
+      )
     end
 
     it "should find cards returned by virtual cards" do
-      expect(Card::Query.new(
-        found_by: 'Image+*type+by name').run.map(&:name).sort
-      ).to eq(Card.search(type: 'Image').map(&:name).sort)
+      expect(Card::Query.run(
+        found_by: 'Image+*type+by name', return: :name, sort: :name
+      )).to eq(
+        Card.search type: 'Image', return: :name, sort: :name
+      )
     end
 
     it "should play nicely with other properties and relationships" do
-      found_by_simple = Card::Query.new(
+      expect(Card::Query.run(
         plus: { found_by: 'Simple Search' }, return: :name, sort: :name
-      ).run
-
-      plus_name_A = Card::Query.new(
+      )).to eq( Card::Query.run(
         plus: { name: 'A' }, return: :name, sort: :name
-      ).run
-
-      expect(found_by_simple).to eq(plus_name_A)
+      ))
 
       expect(Card::Query.run(
         found_by: 'A+*self', plus: 'C', return: :name, sort: :name
-      )).to eq(%w{ A })
-
+      )).to eq(
+        %w{ A }
+      )
     end
 
     it "should be able to handle _self" do
@@ -544,7 +696,9 @@ describe Card::Query do
         left: {found_by: '_self'},
         right: 'B',
         return: :name
-      ).first).to eq('A+B')
+      ).first).to eq(
+        'A+B'
+      )
     end
 
   end
@@ -555,29 +709,52 @@ describe Card::Query do
 
   describe "relative" do
     it "should clean wql" do
-      query = Card::Query.new( part: "_self",context: 'A' )
-      expect(query.statement[:part]).to eq('A')
+      expect( Card::Query.new(
+        part: "_self",context: 'A'
+      ).statement[:part]).to eq(
+        'A'
+      )
     end
 
     it "should find connection cards" do
-      expect(Card::Query.new( part: "_self", context: 'A' ).run.map(&:name).sort).to eq(["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"])
+      expect(Card::Query.run(
+        part: "_self", context: 'A'
+      ).map(&:name).sort).to eq(
+        ["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"]
+      )
     end
 
     it "should be able to use parts of nonexistent cards in search" do
       expect(Card['B+A']).to be_nil
-      expect(Card::Query.new( left: '_right', right: '_left', context: 'B+A' ).run.map(&:name)).to eq(['A+B'])
+      expect(Card::Query.run(
+        left: '_right', right: '_left', context: 'B+A'
+      ).map(&:name)).to eq(
+        ['A+B']
+      )
     end
 
     it "should find plus cards for _self" do
-      expect(Card::Query.new( plus: "_self", context: "A" ).run.map(&:name).sort).to eq(A_JOINEES)
+      expect(Card::Query.run(
+        plus: "_self", context: "A"
+      ).map(&:name).sort).to eq(
+        A_JOINEES
+      )
     end
 
     it "should find plus cards for _left" do
-      expect(Card::Query.new( plus: "_left", context: "A+B" ).run.map(&:name).sort).to eq(A_JOINEES)
+      expect(Card::Query.run(
+        plus: "_left", context: "A+B"
+      ).map(&:name).sort).to eq(
+        A_JOINEES
+      )
     end
 
     it "should find plus cards for _right" do
-      expect(Card::Query.new( plus: "_right", context: "C+A" ).run.map(&:name).sort).to eq(A_JOINEES)
+      expect(Card::Query.run(
+        plus: "_right", context: "C+A"
+      ).map(&:name).sort).to eq(
+        A_JOINEES
+      )
     end
 
   end
@@ -586,7 +763,8 @@ describe Card::Query do
   describe "nested permissions" do
     it "are generated by default" do
       perm_count = 0
-      Card::Query.new( { left: {name: "X"}}).sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
+      sql = Card::Query.new(left: { name: "X" }).sql
+      sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
         perm_count+=1
       end
       expect(perm_count).to eq(2)
@@ -595,7 +773,8 @@ describe Card::Query do
 #    it "are not generated inside .without_nested_permissions block" do
 #      perm_count = 0
 #      Card::Query.without_nested_permissions do
-#        Card::Query.new( { left: {name: "X"}}).sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
+#        Card::Query.run(
+#      { left: {name: "X"}}).sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
 #          perm_count+=1
 #        end
 #      end
@@ -606,7 +785,9 @@ describe Card::Query do
   #describe "return values" do
   #  # FIXME: should do other return thingies here
   #  it "returns name_content" do
-  #    Card::Query.new( { name: "A+B", return: "name_content" } ).run.should == {
+  #    Card::Query.run(
+  #    { name: "A+B", return: "name_content" }
+  #    ).should == {
   #      "A+B" => "AlphaBeta"
   #    }
   #  end

--- a/card/spec/lib/card/query_spec.rb
+++ b/card/spec/lib/card/query_spec.rb
@@ -1,43 +1,43 @@
 # -*- encoding : utf-8 -*-
 
-A_JOINEES = ["B", "C", "D", "E", "F"]
+A_JOINEES = %w{ B C D E F }
 
-CARDS_MATCHING_TWO = ["Two","One+Two","One+Two+Three","Joe User"].sort
+CARDS_MATCHING_TWO = ['Joe User', 'One+Two', 'One+Two+Three', 'Two']
 
 describe Card::Query do
 
   describe 'append' do
-    it "should find real cards" do
+    it 'should find real cards' do
       expect(Card::Query.run(
         name: [:in, 'C', 'D', 'F'],
         append: 'A'
       ).map(&:name).sort).to eq(
-        ["C+A", "D+A", "F+A"]
+        ['C+A', 'D+A', 'F+A']
       )
     end
 
-    it "should absolutize names" do
+    it 'should absolutize names' do
       expect(Card::Query.run(
         name: [:in, 'C', 'D', 'F'],
         append: '_right',
         context: 'B+A'
       ).map(&:name).sort).to eq(
-        ["C+A", "D+A", "F+A"]
+        ['C+A', 'D+A', 'F+A']
       )
     end
 
-    it "should find virtual cards" do
+    it 'should find virtual cards' do
       expect(Card::Query.run(
         name: [:in, 'C', 'D'],
         append: '*plus cards'
       ).map(&:name).sort).to eq(
-        ["C+*plus cards", "D+*plus cards"]
+        ['C+*plus cards', 'D+*plus cards']
       )
     end
   end
 
-  describe "in" do
-    it "should work for content options" do
+  describe 'in' do
+    it 'should work for content options' do
       expect(Card::Query.run(
         in: ['AlphaBeta', 'Theta']
       ).map(&:name).sort).to eq(
@@ -45,7 +45,7 @@ describe Card::Query do
       )
     end
 
-    it "should find the same thing in full syntax" do
+    it 'should find the same thing in full syntax' do
       expect(Card::Query.run(
         content: [:in,'Theta','AlphaBeta']
       ).map(&:name).sort).to eq(
@@ -53,7 +53,7 @@ describe Card::Query do
       )
     end
 
-    it "should work on types" do
+    it 'should work on types' do
       expect(Card::Query.run(
         type: [:in,'Cardtype E', 'Cardtype F']
       ).map(&:name).sort).to eq(
@@ -63,17 +63,17 @@ describe Card::Query do
   end
 
 
-  describe "member_of/member" do
-    it "member_of should find members" do
+  describe 'member_of/member' do
+    it 'member_of should find members' do
       expect(Card::Query.run(
-        member_of: "r1"
+        member_of: 'r1'
       ).map(&:name).sort).to eq(
         %w(u1 u2 u3)
       )
     end
-    it "member should find roles" do
+    it 'member should find roles' do
       expect(Card::Query.run(
-        member: { match: "u1" }
+        member: { match: 'u1' }
       ).map(&:name).sort).to eq(
         %w(r1 r2 r3)
       )
@@ -81,18 +81,18 @@ describe Card::Query do
   end
 
 
-  describe "not" do
-    it "should exclude cards matching not criteria" do
+  describe 'not' do
+    it 'should exclude cards matching not criteria' do
       expect(Card::Query.run(
-        plus: "A", not: {plus: "A+B"}
+        plus: 'A', not: {plus: 'A+B'}
       ).map(&:name).sort).to eq(
         %w{ B D E F }
       )
     end
   end
 
-  describe "multiple values" do
-    it "should handle multiple values for relational keys" do
+  describe 'multiple values' do
+    it 'should handle multiple values for relational keys' do
       expect(Card::Query.run(
         member_of: [:all, { name: 'r1' }, { key: 'r2' }], return: :name
       ).sort).to eq(
@@ -118,7 +118,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle multiple values for plus_relational keys" do
+    it 'should handle multiple values for plus_relational keys' do
       expect(Card::Query.run(
         right_plus: [:all, 'e', 'c'],
         return: :name
@@ -139,7 +139,7 @@ describe Card::Query do
       ) # NOT interpreted as multi-value
     end
 
-    it "should handle multiple values for plus_relational keys" do
+    it 'should handle multiple values for plus_relational keys' do
       expect(Card::Query.run(
         refer_to: [:and, 'a', 'b'], return: :name
       ).sort).to eq(
@@ -162,45 +162,45 @@ describe Card::Query do
   end
 
 
-  describe "edited_by/editor_of" do
-    it "should find card edited by joe using subquery" do
+  describe 'edited_by/editor_of' do
+    it 'should find card edited by joe using subquery' do
       expect(Card::Query.run(
-        edited_by: { match: "Joe User" }, sort: "name"
+        edited_by: { match: 'Joe User' }, sort: 'name'
       )).to include(
-        Card["JoeLater"], Card["JoeNow"]
+        Card['JoeLater'], Card['JoeNow']
       )
     end
 
-    it "should find card edited by Wagn Bot" do
+    it 'should find card edited by Wagn Bot' do
       #this is a weak test, since it gives the name, but different sorting mechanisms in other db setups
-      #was having it return *account in some cases and "A" in others
+      #was having it return *account in some cases and 'A' in others
       expect(Card::Query.run(
-        edited_by: "Wagn Bot", name: 'A', return: 'name', limit: 1
+        edited_by: 'Wagn Bot', name: 'A', return: 'name', limit: 1
       ).first).to eq(
-        "A"
+        'A'
       )
     end
 
-    it "should fail gracefully if user isn't there" do
+    it 'should fail gracefully if user isn\'t there' do
       expect(Card::Query.run(
-        edited_by: "Joe LUser", sort: "name", limit: 1
+        edited_by: 'Joe LUser', sort: 'name', limit: 1
       )).to eq(
         []
       )
     end
 
-    it "should not give duplicate results for multiple edits" do
-      c=Card["JoeNow"]
-      c.content="testagagin"
+    it 'should not give duplicate results for multiple edits' do
+      c=Card['JoeNow']
+      c.content = 'testagagin'
       c.save
-      c.content="test3"
+      c.content = 'test3'
       c.save!
       expect(Card::Query.run(
-        edited_by: "Joe User"
-      ).map(&:name).count("JoeNow")).to eq 1
+        edited_by: 'Joe User'
+      ).map(&:name).count('JoeNow')).to eq 1
     end
 
-    it "should find joe user among card's editors" do
+    it 'should find joe user among card\'s editors' do
       expect(Card::Query.run(
         editor_of: 'JoeLater'
       ).map(&:name)).to eq(
@@ -209,7 +209,7 @@ describe Card::Query do
     end
   end
 
-  describe "created_by/creator_of" do
+  describe 'created_by/creator_of' do
     before do
       Card.create name: 'Create Test', content: 'sufficiently distinctive'
     end
@@ -223,7 +223,7 @@ describe Card::Query do
       )
     end
 
-    it "should find card created by Joe User" do
+    it 'should find card created by Joe User' do
       expect(Card::Query.run(
         created_by: 'Joe User', eq: 'sufficiently distinctive'
       ).first.name).to eq(
@@ -232,7 +232,7 @@ describe Card::Query do
     end
   end
 
-  describe "last_edited_by/last_editor_of" do
+  describe 'last_edited_by/last_editor_of' do
     before do
       c=Card.fetch('A')
       c.content='peculicious'
@@ -247,7 +247,7 @@ describe Card::Query do
       )
     end
 
-    it "should find card created by Joe User" do
+    it 'should find card created by Joe User' do
       expect(Card::Query.run(
         last_edited_by: 'Joe User', eq: 'peculicious'
       ).first.name).to eq(
@@ -256,59 +256,59 @@ describe Card::Query do
     end
   end
 
-  describe "keyword" do
-    it "should escape nonword characters" do
+  describe 'keyword' do
+    it 'should escape nonword characters' do
       expect(Card::Query.run(
-        match: "two :(!"
+        match: 'two :(!'
       ).map(&:name).sort).to eq(
         CARDS_MATCHING_TWO
       )
     end
   end
 
-  describe "search count" do
-    it "should return integer" do
+  describe 'search count' do
+    it 'should return integer' do
       keyword_search = Card.create!(
-        name: "ksearch", type: 'Search', content: '{"match":"$keyword"}'
+        name: 'ksearch', type: 'Search', content: '{"match":"$keyword"}'
       )
       expect(keyword_search.count(
-        vars: {keyword: "two"}
+        vars: {keyword: 'two'}
       )).to eq(
         CARDS_MATCHING_TWO.length
       )
     end
   end
 
-  describe "cgi_params" do
-    it "should match content from cgi" do
+  describe 'cgi_params' do
+    it 'should match content from cgi' do
       expect(Card::Query.run(
-        match: "$keyword", vars: {keyword: "two"}
+        match: '$keyword', vars: {keyword: 'two'}
       ).map(&:name).sort).to eq(
         CARDS_MATCHING_TWO
       )
     end
   end
 
-  describe "content equality" do
-    it "should match content explicitly" do
+  describe 'content equality' do
+    it 'should match content explicitly' do
       expect(Card::Query.run(
         content: ['=',"I'm number two"]
       ).map(&:name)).to eq(
-        ["Joe User"]
+        ['Joe User']
       )
     end
 
-    it "should match via shortcut" do
+    it 'should match via shortcut' do
       expect(Card::Query.run(
         '='=>"I'm number two"
       ).map(&:name)).to eq(
-        ["Joe User"]
+        ['Joe User']
       )
     end
   end
 
-  describe "links" do
-    it "should handle refer_to" do
+  describe 'links' do
+    it 'should handle refer_to' do
       expect(Card::Query.run(
         refer_to: 'Z'
       ).map(&:name).sort).to eq(
@@ -316,7 +316,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle link_to" do
+    it 'should handle link_to' do
       expect(Card::Query.run(
         link_to: 'Z'
       ).map(&:name)).to eq(
@@ -324,7 +324,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle include" do
+    it 'should handle include' do
       expect(Card::Query.run(
         include: 'Z'
       ).map(&:name)).to eq(
@@ -332,7 +332,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle linked_to_by" do
+    it 'should handle linked_to_by' do
       expect(Card::Query.run(
         linked_to_by: 'A'
       ).map(&:name)).to eq(
@@ -340,7 +340,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle included_by" do
+    it 'should handle included_by' do
       expect(Card::Query.run(
         included_by: 'B'
       ).map(&:name)).to eq(
@@ -348,7 +348,7 @@ describe Card::Query do
       )
     end
 
-    it "should handle referred_to_by" do
+    it 'should handle referred_to_by' do
       expect(Card::Query.run(
         referred_to_by: 'X'
       ).map(&:name).sort).to eq(
@@ -357,176 +357,185 @@ describe Card::Query do
     end
   end
 
-  describe "relative links" do
-    it("should handle relative refer_to")  { expect(Card::Query.run(
+  describe 'relative links' do
+    it('should handle relative refer_to')  { expect(Card::Query.run(
       refer_to: '_self', context: 'Z'
       ).map(&:name).sort).to eq(%w{ A B }) }
   end
 
-  describe "permissions" do
-    it "should not find cards not in group" do
+  describe 'permissions' do
+    it 'should not find cards not in group' do
       Card::Auth.as_bot  do
-        Card.create name: "C+*self+*read", type: 'Pointer', content: "[[R1]]"
+        Card.create name: 'C+*self+*read', type: 'Pointer', content: '[[R1]]'
       end
       expect(Card::Query.run(
-        plus: "A"
+        plus: 'A'
       ).map(&:name).sort).to eq(
         %w{ B D E F }
       )
     end
   end
 
-  describe "basics" do
-    it "should be case insensitive for name" do
+  describe 'basics' do
+    it 'should be case insensitive for name' do
       expect(Card::Query.run(
-        name: "a"
+        name: 'a'
       ).first.name).to eq(
         'A'
       )
     end
 
-    it "should find plus cards" do
+    it 'should find plus cards' do
       expect(Card::Query.run(
-        plus: "A"
+        plus: 'A'
       ).map(&:name).sort).to eq(
         A_JOINEES
       )
     end
 
-    it "should find connection cards" do
+    it 'should find connection cards' do
       expect(Card::Query.run(
-        part: "A"
+        part: 'A'
       ).map(&:name).sort).to eq(
-        ["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"]
+        %w{ A+B A+C A+D A+E C+A D+A F+A }
       )
     end
 
-    it "should find left connection cards" do
+    it 'should find left connection cards' do
       expect(Card::Query.run(
-      left: "A"
-      ).map(&:name).sort).to eq(["A+B", "A+C", "A+D", "A+E"])
+        left: 'A'
+      ).map(&:name).sort).to eq(
+        %w{ A+B A+C A+D A+E }
+      )
     end
 
-    it "should find right connection cards" do
-      [ { right: "A"},                         # query by name
-        { right: { content: "Alpha [[Z]]" } }  # query by content
+    it 'should find right connection cards' do
+      [ { right: 'A'},                         # query by name
+        { right: { content: 'Alpha [[Z]]' } }  # query by content
       ].each do |statement|
+
         expect(Card::Query.run(
-      statement
-      ).map(&:name).sort).to eq(["C+A", "D+A", "F+A"])
+          statement
+        ).map(&:name).sort).to eq(
+          %w{ C+A D+A F+A }
+        )
       end
     end
 
-    it "should return count" do
-      expect(Card.count_by_wql( part: "A" )).to eq(7)
+    it 'should return count' do
+      expect(Card.count_by_wql( part: 'A' )).to eq(7)
     end
   end
 
-  describe "limit and offset" do
-    it "should return limit" do
+  describe 'limit and offset' do
+    it 'should return limit' do
       expect(Card::Query.run(
-      part: "A", limit: 5
-      ).size).to eq(5)
+        part: 'A', limit: 5
+      ).size).to eq(
+        5
+      )
     end
 
-    it "should not break if offset but no limit" do
+    it 'should not break if offset but no limit' do
       expect(Card::Query.run(
-      part: "A", offset: 5
-      ).size).not_to eq(0)
+        part: 'A', offset: 5
+      ).size).not_to eq(
+        0
+      )
     end
 
   end
 
-  describe "type" do
+  describe 'type' do
     user_cards = [
-      "Big Brother", "Joe Admin", "Joe Camel", "Joe User", "John",
-      "Narcissist", "No Count", "Optic fan", "Sample User", "Sara",
-      "Sunglasses fan", "u1", "u2", "u3"
+      'Big Brother', 'Joe Admin', 'Joe Camel', 'Joe User', 'John',
+      'Narcissist', 'No Count', 'Optic fan', 'Sample User', 'Sara',
+      'Sunglasses fan', 'u1', 'u2', 'u3'
     ].sort
 
-    it "should find cards of this type" do
+    it 'should find cards of this type' do
       expect(Card::Query.run(
-        type: "_self", context: 'User'
+        type: '_self', context: 'User'
       ).map(&:name).sort).to eq(
         user_cards
       )
     end
 
-    it "should find User cards " do
+    it 'should find User cards ' do
       expect(Card::Query.run(
-        type: "User"
+        type: 'User'
       ).map(&:name).sort).to eq(
         user_cards
       )
     end
 
-    it "should handle casespace variants" do
+    it 'should handle casespace variants' do
       expect(Card::Query.run(
-        type: "users"
+        type: 'users'
       ).map(&:name).sort).to eq(
         user_cards
       )
     end
   end
 
-  describe "trash handling" do
-    it "should not find cards in the trash" do
-      Card["A+B"].delete!
+  describe 'trash handling' do
+    it 'should not find cards in the trash' do
+      Card['A+B'].delete!
       expect(Card::Query.run(
-        left: "A"
+        left: 'A'
       ).map(&:name).sort).to eq(
-        ["A+C", "A+D", "A+E"]
+        ['A+C', 'A+D', 'A+E']
       )
     end
   end
 
-  describe "order" do
-    it "should sort by create" do
-      Card.create! name: "classic bootstrap skin head"
+  describe 'order' do
+    it 'should sort by create' do
+      Card.create! name: 'classic bootstrap skin head'
       # classic skin head is created more recently than classic skin,
       # which is in the seed data
       expect( Card::Query.run(
-        sort: "create", name: [:match,'classic bootstrap skin']
+        sort: 'create', name: [:match,'classic bootstrap skin']
       ).map(&:name) ).to eq(
-        ["classic bootstrap skin","classic bootstrap skin head"]
+        ['classic bootstrap skin', 'classic bootstrap skin head']
       )
     end
 
-    it "should sort by name" do
+    it 'should sort by name' do
       expect(Card::Query.run(
-        name: %w{ in B Z A Y C X }, sort: "alpha", dir: "desc"
+        name: %w{ in B Z A Y C X }, sort: 'alpha', dir: 'desc'
       ).map(&:name)).to eq(
         %w{ Z Y X C B A }
       )
 
       expect(Card::Query.run(
-        name: %w{ in B Z A Y C X }, sort: "name", dir: "desc"
+        name: %w{ in B Z A Y C X }, sort: 'name', dir: 'desc'
       ).map(&:name)).to eq(
         %w{ Z Y X C B A }
       )
       #Card.create! name: 'the alphabet'
       #Card::Query.run(
-      #name: ["in", "B", "C", "the alphabet"], sort: "name"
-      #).map(&:name).should ==  ["the alphabet", "B", "C"]
+      #name: ['in', 'B', 'C', 'the alphabet'], sort: 'name'
+      #).map(&:name).should ==  ['the alphabet', 'B', 'C']
     end
 
-    it "should sort by content" do
+    it 'should sort by content' do
       expect(Card::Query.run(
-        name: %w{ in Z T A }, sort: "content"
+        name: %w{ in Z T A }, sort: 'content'
       ).map(&:name)).to eq(
         %w{ A Z T }
       )
     end
 
-    it "should play nice with match" do
+    it 'should play nice with match' do
       expect(Card::Query.run(
-        match: 'Z', type: 'Basic', sort: "content"
+        match: 'Z', type: 'Basic', sort: 'content'
       ).map(&:name)).to eq(
         %w{ A B Z }
       )
     end
 
-    it "should sort by plus card content" do
+    it 'should sort by plus card content' do
       Card::Auth.as_bot do
         c = Card.fetch('Setting+*self+*table of contents')
         c.content = '10'
@@ -542,7 +551,7 @@ describe Card::Query do
       end
     end
 
-    it "should sort by count" do
+    it 'should sort by count' do
       Card::Auth.as_bot do
         expect(Card::Query.run(
           name: [:in,'*always', '*never', '*edited'],
@@ -553,48 +562,49 @@ describe Card::Query do
       end
     end
 
-  #  it "should sort by update" do
-  #    # do this on a restricted set so it won't change every time we add a card..
+  #  it 'should sort by update' do
+  #    # do this on a restricted set so it won't change every time we
+  #    #  add a card..
   #    Card::Query.run(
-  #    match: "two", sort: "update", dir: "desc"
-  #    ).map(&:name).should == ["One+Two+Three", "One+Two","Two","Joe User"]
-  #    Card["Two"].update_attributes! content: "new bar"
+  #    match: 'two', sort: 'update', dir: 'desc'
+  #    ).map(&:name).should == ['One+Two+Three', 'One+Two','Two','Joe User']
+  #    Card['Two'].update_attributes! content: 'new bar'
   #    Card::Query.run(
-  #    match: "two", sort: "update", dir: "desc"
-  #    ).map(&:name).should == ["Two","One+Two+Three", "One+Two","Joe User"]
+  #    match: 'two', sort: 'update', dir: 'desc'
+  #    ).map(&:name).should == ['Two','One+Two+Three', 'One+Two','Joe User']
   #  end
   #
 
   end
 
-  describe "match" do
-    it "should reach content and name via shortcut" do
+  describe 'match' do
+    it 'should reach content and name via shortcut' do
       expect(Card::Query.run(
-        match: "two"
+        match: 'two'
       ).map(&:name).sort).to eq(
         CARDS_MATCHING_TWO
       )
     end
 
-    it "should get only content when content is explicit" do
+    it 'should get only content when content is explicit' do
       expect(Card::Query.run(
-        content: [:match, "two"]
+        content: [:match, 'two']
       ).map(&:name).sort).to eq(
-        ["Joe User"]
+        ['Joe User']
       )
     end
 
-    it "should get only name when name is explicit" do
+    it 'should get only name when name is explicit' do
       expect(Card::Query.run(
-        name: [:match, "two"]
+        name: [:match, 'two']
       ).map(&:name).sort).to eq(
-        ["One+Two","One+Two+Three","Two"].sort
+        ['One+Two','One+Two+Three','Two'].sort
       )
     end
   end
 
-  describe "and" do
-    it "should act as a simple passthrough" do
+  describe 'and' do
+    it 'should act as a simple passthrough' do
       expect(Card::Query.run(
         and: { match: 'two' }
       ).map(&:name).sort).to eq(
@@ -602,13 +612,13 @@ describe Card::Query do
       )
 
       expect(Card::Query.run(
-        and: {}, type: "Cardtype E"
+        and: {}, type: 'Cardtype E'
       ).first.name).to eq(
         'type-e-card'
       )
     end
 
-    it "should work within 'or'" do
+    it 'should work within "or"' do
       expect(Card::Query.run(
         or: { name: 'Z', and: { left: 'A', right: 'C' } },
         return: :name, sort: :name
@@ -618,30 +628,30 @@ describe Card::Query do
     end
   end
 
-  describe "any/or" do
-    it "should work with :plus" do
+  describe 'any/or' do
+    it 'should work with :plus' do
       expect(Card::Query.run(
-        plus: "A", or: { name: 'B', match: 'K' }, return: :name, sort: :name
+        plus: 'A', or: { name: 'B', match: 'K' }, return: :name, sort: :name
       )).to eq(
         %w{ B }
       )
 
       expect(Card::Query.run(
-        plus: "A", any: { name: 'B', match: 'K'}, return: :name, sort: :name
+        plus: 'A', any: { name: 'B', match: 'K'}, return: :name, sort: :name
       )).to eq(
         %w{ B }
       )
 
       expect(Card::Query.run(
-        or: { right_plus: "A", plus: 'B' }, return: :name, sort: :name
+        or: { right_plus: 'A', plus: 'B' }, return: :name, sort: :name
       )).to eq(
         %w{ A C D F }
       )
     end
   end
 
-  describe "offset" do
-    it "should not break count" do
+  describe 'offset' do
+    it 'should not break count' do
       expect(Card.count_by_wql(
         match: 'two', offset: 1
       )).to eq(
@@ -652,7 +662,7 @@ describe Card::Query do
 
 
   #=end
-  describe "found_by" do
+  describe 'found_by' do
     before do
       Card::Auth.current_id = Card::WagnBotID
       c = Card.create(
@@ -660,7 +670,7 @@ describe Card::Query do
       )
     end
 
-    it "should find cards returned by search of given name" do
+    it 'should find cards returned by search of given name' do
       expect(Card::Query.run(
         found_by: 'Simple Search'
       ).first.name).to eq(
@@ -668,7 +678,7 @@ describe Card::Query do
       )
     end
 
-    it "should find cards returned by virtual cards" do
+    it 'should find cards returned by virtual cards' do
       expect(Card::Query.run(
         found_by: 'Image+*type+by name', return: :name, sort: :name
       )).to eq(
@@ -676,7 +686,7 @@ describe Card::Query do
       )
     end
 
-    it "should play nicely with other properties and relationships" do
+    it 'should play nicely with other properties and relationships' do
       expect(Card::Query.run(
         plus: { found_by: 'Simple Search' }, return: :name, sort: :name
       )).to eq( Card::Query.run(
@@ -690,7 +700,7 @@ describe Card::Query do
       )
     end
 
-    it "should be able to handle _self" do
+    it 'should be able to handle _self' do
       expect(Card::Query.run(
         context: 'Simple Search',
         left: {found_by: '_self'},
@@ -703,28 +713,24 @@ describe Card::Query do
 
   end
 
-
-
-  #=end
-
-  describe "relative" do
-    it "should clean wql" do
+  describe 'relative' do
+    it 'should clean wql' do
       expect( Card::Query.new(
-        part: "_self",context: 'A'
+        part: '_self',context: 'A'
       ).statement[:part]).to eq(
         'A'
       )
     end
 
-    it "should find connection cards" do
+    it 'should find connection cards' do
       expect(Card::Query.run(
-        part: "_self", context: 'A'
+        part: '_self', context: 'A'
       ).map(&:name).sort).to eq(
-        ["A+B", "A+C", "A+D", "A+E", "C+A", "D+A", "F+A"]
+        %w{ A+B A+C A+D A+E C+A D+A F+A }
       )
     end
 
-    it "should be able to use parts of nonexistent cards in search" do
+    it 'should be able to use parts of nonexistent cards in search' do
       expect(Card['B+A']).to be_nil
       expect(Card::Query.run(
         left: '_right', right: '_left', context: 'B+A'
@@ -733,25 +739,25 @@ describe Card::Query do
       )
     end
 
-    it "should find plus cards for _self" do
+    it 'should find plus cards for _self' do
       expect(Card::Query.run(
-        plus: "_self", context: "A"
+        plus: '_self', context: 'A'
       ).map(&:name).sort).to eq(
         A_JOINEES
       )
     end
 
-    it "should find plus cards for _left" do
+    it 'should find plus cards for _left' do
       expect(Card::Query.run(
-        plus: "_left", context: "A+B"
+        plus: '_left', context: 'A+B'
       ).map(&:name).sort).to eq(
         A_JOINEES
       )
     end
 
-    it "should find plus cards for _right" do
+    it 'should find plus cards for _right' do
       expect(Card::Query.run(
-        plus: "_right", context: "C+A"
+        plus: '_right', context: 'C+A'
       ).map(&:name).sort).to eq(
         A_JOINEES
       )
@@ -760,21 +766,21 @@ describe Card::Query do
   end
 
 
-  describe "nested permissions" do
-    it "are generated by default" do
+  describe 'nested permissions' do
+    it 'are generated by default' do
       perm_count = 0
-      sql = Card::Query.new(left: { name: "X" }).sql
+      sql = Card::Query.new(left: { name: 'X' }).sql
       sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
         perm_count+=1
       end
       expect(perm_count).to eq(2)
     end
 
-#    it "are not generated inside .without_nested_permissions block" do
+#    it 'are not generated inside .without_nested_permissions block' do
 #      perm_count = 0
 #      Card::Query.without_nested_permissions do
 #        Card::Query.run(
-#      { left: {name: "X"}}).sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
+#      { left: {name: 'X'}}).sql.scan( /read_rule_id IN \([\d\,]+\)/ ) do |m|
 #          perm_count+=1
 #        end
 #      end
@@ -782,13 +788,13 @@ describe Card::Query do
 #    end
   end
 
-  #describe "return values" do
+  #describe 'return values' do
   #  # FIXME: should do other return thingies here
-  #  it "returns name_content" do
+  #  it 'returns name_content' do
   #    Card::Query.run(
-  #    { name: "A+B", return: "name_content" }
+  #    { name: 'A+B', return: 'name_content' }
   #    ).should == {
-  #      "A+B" => "AlphaBeta"
+  #      'A+B' => 'AlphaBeta'
   #    }
   #  end
   #end

--- a/card/spec/lib/card/query_spec.rb
+++ b/card/spec/lib/card/query_spec.rb
@@ -8,67 +8,155 @@ describe Card::Query do
 
   describe 'append' do
     it "should find real cards" do
-      expect(Card::Query.new(name: [:in, 'C', 'D', 'F'], append: 'A' ).run.map(&:name).sort).to eq(["C+A", "D+A", "F+A"])
+      expect(Card::Query.run(
+        name: [:in, 'C', 'D', 'F'],
+        append: 'A'
+      ).map(&:name).sort).to eq(
+        ["C+A", "D+A", "F+A"]
+      )
     end
 
     it "should absolutize names" do
-      expect(Card::Query.new(name: [:in, 'C', 'D', 'F'], append: '_right', context: 'B+A' ).run.map(&:name).sort).to eq(["C+A", "D+A", "F+A"])
+      expect(Card::Query.run(
+        name: [:in, 'C', 'D', 'F'],
+        append: '_right',
+        context: 'B+A'
+      ).map(&:name).sort).to eq(
+        ["C+A", "D+A", "F+A"]
+      )
     end
 
     it "should find virtual cards" do
-      expect(Card::Query.new(name: [:in, 'C', 'D'], append: '*plus cards' ).run.map(&:name).sort).to eq(["C+*plus cards", "D+*plus cards"])
+      expect(Card::Query.run(
+        name: [:in, 'C', 'D'],
+        append: '*plus cards'
+      ).map(&:name).sort).to eq(
+        ["C+*plus cards", "D+*plus cards"]
+      )
     end
   end
 
   describe "in" do
     it "should work for content options" do
-      expect(Card::Query.new(in: ['AlphaBeta', 'Theta']).run.map(&:name).sort).to eq(%w(A+B T))
+      expect(Card::Query.run(
+        in: ['AlphaBeta', 'Theta']
+      ).map(&:name).sort).to eq(
+        %w(A+B T)
+      )
     end
 
     it "should find the same thing in full syntax" do
-      expect(Card::Query.new(content: [:in,'Theta','AlphaBeta']).run.map(&:name).sort).to eq(%w(A+B T))
+      expect(Card::Query.run(
+        content: [:in,'Theta','AlphaBeta']
+      ).map(&:name).sort).to eq(
+        %w(A+B T)
+      )
     end
 
     it "should work on types" do
-      expect(Card::Query.new(type: [:in,'Cardtype E', 'Cardtype F']).run.map(&:name).sort).to eq(%w(type-e-card type-f-card))
+      expect(Card::Query.run(
+        type: [:in,'Cardtype E', 'Cardtype F']
+      ).map(&:name).sort).to eq(
+        %w(type-e-card type-f-card)
+      )
     end
   end
 
 
   describe "member_of/member" do
     it "member_of should find members" do
-      expect(Card::Query.new( member_of: "r1" ).run.map(&:name).sort).to eq(%w(u1 u2 u3))
+      expect(Card::Query.run(
+        member_of: "r1"
+      ).map(&:name).sort).to eq(
+        %w(u1 u2 u3)
+      )
     end
     it "member should find roles" do
-      expect(Card::Query.new( member: {match: "u1"} ).run.map(&:name).sort).to eq(%w(r1 r2 r3))
+      expect(Card::Query.run(
+        member: { match: "u1" }
+      ).map(&:name).sort).to eq(
+        %w(r1 r2 r3)
+      )
     end
   end
 
 
   describe "not" do
     it "should exclude cards matching not criteria" do
-      expect(Card::Query.new(plus: "A", not: {plus: "A+B"}).run.map(&:name).sort).to eq(%w{ B D E F })
+      expect(Card::Query.run(
+        plus: "A", not: {plus: "A+B"}
+      ).map(&:name).sort).to eq(
+        %w{ B D E F }
+      )
     end
   end
 
   describe "multiple values" do
     it "should handle multiple values for relational keys" do
-      expect(Card::Query.new( member_of: [:all, {name: 'r1'}, {key: 'r2'} ], return: :name).run.sort).to eq(%w{ u1 u2 })
-      expect(Card::Query.new( member_of: [      {name: 'r1'}, {key: 'r2'} ], return: :name).run.sort).to eq(%w{ u1 u2 })
-      expect(Card::Query.new( member_of: {any: [{name: 'r1'}, {key: 'r2'} ]},return: :name).run.sort).to eq(%w{ u1 u2 u3 })
-      expect(Card::Query.new( member_of: [:any, {name: 'r1'}, {key: 'r2'} ], return: :name).run.sort).to eq(%w{ u1 u2 u3 })
+      expect(Card::Query.run(
+        member_of: [:all, { name: 'r1' }, { key: 'r2' }], return: :name
+      ).sort).to eq(
+        %w{ u1 u2 }
+      )
+
+      expect(Card::Query.run(
+        member_of: [{ name: 'r1' }, { key: 'r2' }], return: :name
+      ).sort).to eq(
+        %w{ u1 u2 }
+      )
+
+      expect(Card::Query.run(
+        member_of: { any: [{ name: 'r1' }, { key: 'r2' }] }, return: :name
+      ).sort).to eq(
+        %w{ u1 u2 u3 }
+      )
+
+      expect(Card::Query.run(
+        member_of: [:any, { name: 'r1' }, { key: 'r2' } ], return: :name
+      ).sort).to eq(
+        %w{ u1 u2 u3 }
+      )
     end
 
     it "should handle multiple values for plus_relational keys" do
-      expect(Card::Query.new( right_plus: [ :all, 'e', 'c' ], return: :name ).run.sort).to eq(%w{ A }) #explicit conjunction
-      expect(Card::Query.new( right_plus: [ ['e',{}],  'c' ], return: :name ).run.sort).to eq(%w{ A }) # first element is array
-      expect(Card::Query.new( right_plus: [ 'e', 'c'       ], return: :name ).run.sort).to eq([])      # NOT interpreted as multi-value
+      expect(Card::Query.run(
+        right_plus: [:all, 'e', 'c'],
+        return: :name
+      ).sort).to eq(
+        %w{ A }
+      ) #explicit conjunction
+
+      expect(Card::Query.run(
+        right_plus: [['e',{}], 'c' ], return: :name
+      ).sort).to eq(
+        %w{ A }
+      ) # first element is array
+
+      expect(Card::Query.run(
+        right_plus: ['e', 'c'], return: :name
+      ).sort).to eq(
+        []
+      ) # NOT interpreted as multi-value
     end
 
     it "should handle multiple values for plus_relational keys" do
-      expect(Card::Query.new( refer_to: [ :and, 'a', 'b' ], return: :name ).run.sort).to eq(%w{ Y })
-      expect(Card::Query.new( refer_to: [       'a', 'T' ], return: :name ).run.sort).to eq(%w{ X Y })
-      expect(Card::Query.new( refer_to: [ :or,  'b', 'z' ], return: :name ).run.sort).to eq(%w{ A B Y})
+      expect(Card::Query.run(
+        refer_to: [:and, 'a', 'b'], return: :name
+      ).sort).to eq(
+        %w{ Y }
+      )
+
+      expect(Card::Query.run(
+        refer_to: ['a', 'T'], return: :name
+      ).sort).to eq(
+        %w{ X Y }
+      )
+
+      expect(Card::Query.run(
+        refer_to: [:or,  'b', 'z'], return: :name
+      ).sort).to eq(
+        %w{ A B Y}
+      )
     end
 
   end
@@ -76,15 +164,29 @@ describe Card::Query do
 
   describe "edited_by/editor_of" do
     it "should find card edited by joe using subquery" do
-      expect(Card::Query.new(edited_by: {match: "Joe User"}, sort: "name").run).to include(Card["JoeLater"], Card["JoeNow"])
+      expect(Card::Query.run(
+        edited_by: { match: "Joe User" }, sort: "name"
+      )).to include(
+        Card["JoeLater"], Card["JoeNow"]
+      )
     end
+
     it "should find card edited by Wagn Bot" do
       #this is a weak test, since it gives the name, but different sorting mechanisms in other db setups
       #was having it return *account in some cases and "A" in others
-      expect(Card::Query.new(edited_by: "Wagn Bot", name: 'A', return: 'name', limit: 1).run.first).to eq("A")
+      expect(Card::Query.run(
+        edited_by: "Wagn Bot", name: 'A', return: 'name', limit: 1
+      ).first).to eq(
+        "A"
+      )
     end
+
     it "should fail gracefully if user isn't there" do
-      expect(Card::Query.new(edited_by: "Joe LUser", sort: "name", limit: 1).run).to eq([])
+      expect(Card::Query.run(
+        edited_by: "Joe LUser", sort: "name", limit: 1
+      )).to eq(
+        []
+      )
     end
 
     it "should not give duplicate results for multiple edits" do
@@ -93,11 +195,17 @@ describe Card::Query do
       c.save
       c.content="test3"
       c.save!
-      expect(Card::Query.new(edited_by: "Joe User").run.map(&:name).count("JoeNow")).to eq 1
+      expect(Card::Query.run(
+        edited_by: "Joe User"
+      ).map(&:name).count("JoeNow")).to eq 1
     end
 
     it "should find joe user among card's editors" do
-      expect(Card::Query.new(editor_of: 'JoeLater').run.map(&:name)).to eq(['Joe User'])
+      expect(Card::Query.run(
+        editor_of: 'JoeLater'
+      ).map(&:name)).to eq(
+        ['Joe User']
+      )
     end
   end
 
@@ -108,11 +216,19 @@ describe Card::Query do
 
     it "should find Joe User as the card's creator" do
       c = Card.fetch 'Create Test'
-      expect(Card::Query.new(creator_of: 'Create Test').run.first.name).to eq('Joe User')
+      expect(Card::Query.run(
+        creator_of: 'Create Test'
+      ).first.name).to eq(
+        'Joe User'
+      )
     end
 
     it "should find card created by Joe User" do
-      expect(Card::Query.new(created_by: 'Joe User', eq: 'sufficiently distinctive').run.first.name).to eq('Create Test')
+      expect(Card::Query.run(
+        created_by: 'Joe User', eq: 'sufficiently distinctive'
+      ).first.name).to eq(
+        'Create Test'
+      )
     end
   end
 
@@ -124,49 +240,82 @@ describe Card::Query do
     end
 
     it "should find Joe User as the card's last editor" do
-      expect(Card::Query.new(last_editor_of: 'A').run.first.name).to eq('Joe User')
+      expect(Card::Query.run(
+        last_editor_of: 'A'
+      ).first.name).to eq(
+        'Joe User'
+      )
     end
 
     it "should find card created by Joe User" do
-      expect(Card::Query.new(last_edited_by: 'Joe User', eq: 'peculicious').run.first.name).to eq('A')
+      expect(Card::Query.run(
+        last_edited_by: 'Joe User', eq: 'peculicious'
+      ).first.name).to eq(
+        'A'
+      )
     end
   end
 
   describe "keyword" do
     it "should escape nonword characters" do
-      expect(Card::Query.new( match: "two :(!").run.map(&:name).sort).to eq(CARDS_MATCHING_TWO)
+      expect(Card::Query.run(
+        match: "two :(!"
+      ).map(&:name).sort).to eq(
+        CARDS_MATCHING_TWO
+      )
     end
   end
 
   describe "search count" do
-    it "should count search" do
-      s = Card.create! name: "ksearch", type: 'Search', content: '{"match":"$keyword"}'
-      expect(s.count(vars: {keyword: "two"})).to eq(CARDS_MATCHING_TWO.length)
+    it "should return integer" do
+      keyword_search = Card.create!(
+        name: "ksearch", type: 'Search', content: '{"match":"$keyword"}'
+      )
+      expect(keyword_search.count(
+        vars: {keyword: "two"}
+      )).to eq(
+        CARDS_MATCHING_TWO.length
+      )
     end
   end
-
 
   describe "cgi_params" do
     it "should match content from cgi" do
-      expect(Card::Query.new( match: "$keyword", vars: {keyword: "two"}).run.map(&:name).sort).to eq(CARDS_MATCHING_TWO)
+      expect(Card::Query.run(
+        match: "$keyword", vars: {keyword: "two"}
+      ).map(&:name).sort).to eq(
+        CARDS_MATCHING_TWO
+      )
     end
   end
-
-
 
   describe "content equality" do
     it "should match content explicitly" do
-      expect(Card::Query.new( content: ['=',"I'm number two"] ).run.map(&:name)).to eq(["Joe User"])
+      expect(Card::Query.run(
+        content: ['=',"I'm number two"]
+      ).map(&:name)).to eq(
+        ["Joe User"]
+      )
     end
+
     it "should match via shortcut" do
-      expect(Card::Query.new( '='=>"I'm number two" ).run.map(&:name)).to eq(["Joe User"])
+      expect(Card::Query.run(
+        '='=>"I'm number two"
+      ).map(&:name)).to eq(
+        ["Joe User"]
+      )
     end
   end
 
-
   describe "links" do
+    it "should handle refer_to" do
+      expect(Card::Query.run(
+        refer_to: 'Z'
+      ).map(&:name).sort).to eq(
+        %w{ A B }
+      )
+    end
 
-    it("should handle refer_to")      { expect(Card::Query.new( refer_to: 'Z').run.map(&:name).sort).to eq(%w{ A B }) }
     it("should handle link_to")       { expect(Card::Query.new( link_to: 'Z').run.map(&:name)).to eq(%w{ A }) }
     it("should handle include" )      { expect(Card::Query.new( include: 'Z').run.map(&:name)).to eq(%w{ B }) }
     it("should handle linked_to_by")   { expect(Card::Query.new( linked_to_by: 'A').run.map(&:name)).to eq(%w{ Z }) }
@@ -361,21 +510,41 @@ describe Card::Query do
     end
 
     it "should find cards returned by search of given name" do
-      expect(Card::Query.new(found_by: 'Simple Search').run.first.name).to eq('A')
+      expect(Card::Query.new(
+        found_by: 'Simple Search'
+      ).run.first.name).to eq('A')
     end
+
     it "should find cards returned by virtual cards" do
-      expect(Card::Query.new(found_by: 'Image+*type+by name').run.map(&:name).sort).to eq(Card.search(type: 'Image').map(&:name).sort)
+      expect(Card::Query.new(
+        found_by: 'Image+*type+by name').run.map(&:name).sort
+      ).to eq(Card.search(type: 'Image').map(&:name).sort)
     end
+
     it "should play nicely with other properties and relationships" do
-      found_by_simple = Card::Query.new( plus: { found_by: 'Simple Search' }, return: :name, sort: :name ).run
-      plus_name_A =     Card::Query.new( plus: { name: 'A'                 }, return: :name, sort: :name ).run
+      found_by_simple = Card::Query.new(
+        plus: { found_by: 'Simple Search' }, return: :name, sort: :name
+      ).run
+
+      plus_name_A = Card::Query.new(
+        plus: { name: 'A' }, return: :name, sort: :name
+      ).run
 
       expect(found_by_simple).to eq(plus_name_A)
-      expect(Card::Query.new(found_by: 'A+*self', plus: 'C').run.map(&:name)).to eq(%w{ A })
+
+      expect(Card::Query.run(
+        found_by: 'A+*self', plus: 'C', return: :name, sort: :name
+      )).to eq(%w{ A })
 
     end
+
     it "should be able to handle _self" do
-      expect(Card::Query.new(context: 'Simple Search', left: {found_by: '_self'}, right: 'B').run.first.name).to eq('A+B')
+      expect(Card::Query.run(
+        context: 'Simple Search',
+        left: {found_by: '_self'},
+        right: 'B',
+        return: :name
+      ).first).to eq('A+B')
     end
 
   end

--- a/card/spec/lib/card/query_spec.rb
+++ b/card/spec/lib/card/query_spec.rb
@@ -84,7 +84,7 @@ describe Card::Query do
   describe 'not' do
     it 'should exclude cards matching not criteria' do
       expect(Card::Query.run(
-        plus: 'A', not: {plus: 'A+B'}
+        plus: 'A', not: { plus: 'A+B' }
       ).map(&:name).sort).to eq(
         %w{ B D E F }
       )
@@ -112,7 +112,7 @@ describe Card::Query do
       )
 
       expect(Card::Query.run(
-        member_of: [:any, { name: 'r1' }, { key: 'r2' } ], return: :name
+        member_of: [:any, { name: 'r1' }, { key: 'r2' }], return: :name
       ).sort).to eq(
         %w{ u1 u2 u3 }
       )
@@ -172,8 +172,9 @@ describe Card::Query do
     end
 
     it 'should find card edited by Wagn Bot' do
-      #this is a weak test, since it gives the name, but different sorting mechanisms in other db setups
-      #was having it return *account in some cases and 'A' in others
+      # this is a weak test, since it gives the name, but different sorting
+      # mechanisms in other db setups
+      # was having it return *account in some cases and 'A' in others
       expect(Card::Query.run(
         edited_by: 'Wagn Bot', name: 'A', return: 'name', limit: 1
       ).first).to eq(
@@ -190,7 +191,7 @@ describe Card::Query do
     end
 
     it 'should not give duplicate results for multiple edits' do
-      c=Card['JoeNow']
+      c = Card['JoeNow']
       c.content = 'testagagin'
       c.save
       c.content = 'test3'
@@ -282,7 +283,7 @@ describe Card::Query do
   describe 'cgi_params' do
     it 'should match content from cgi' do
       expect(Card::Query.run(
-        match: '$keyword', vars: {keyword: 'two'}
+        match: '$keyword', vars: { keyword: 'two' }
       ).map(&:name).sort).to eq(
         CARDS_MATCHING_TWO
       )
@@ -300,7 +301,7 @@ describe Card::Query do
 
     it 'should match via shortcut' do
       expect(Card::Query.run(
-        '='=>"I'm number two"
+        '=' => "I'm number two"
       ).map(&:name)).to eq(
         ['Joe User']
       )
@@ -423,7 +424,7 @@ describe Card::Query do
     end
 
     it 'should return count' do
-      expect(Card.count_by_wql( part: 'A' )).to eq(7)
+      expect(Card.count_by_wql part: 'A').to eq(7)
     end
   end
 
@@ -494,9 +495,9 @@ describe Card::Query do
       Card.create! name: 'classic bootstrap skin head'
       # classic skin head is created more recently than classic skin,
       # which is in the seed data
-      expect( Card::Query.run(
+      expect(Card::Query.run(
         sort: 'create', name: [:match,'classic bootstrap skin']
-      ).map(&:name) ).to eq(
+      ).map(&:name)).to eq(
         ['classic bootstrap skin', 'classic bootstrap skin head']
       )
     end
@@ -544,7 +545,7 @@ describe Card::Query do
 
         expect(Card::Query.run(
           right_plus: '*table of contents',
-          sort: { right: '*table_of_contents'}, sort_as: 'integer'
+          sort: { right: '*table_of_contents' }, sort_as: 'integer'
         ).map(&:name)).to eq(
           %w{ *all Basic+*type Setting+*self }
         )
@@ -554,7 +555,7 @@ describe Card::Query do
     it 'should sort by count' do
       Card::Auth.as_bot do
         expect(Card::Query.run(
-          name: [:in,'*always', '*never', '*edited'],
+          name: [:in, '*always', '*never', '*edited'],
           sort: { right: '*follow', item: 'referred_to', return: 'count' }
         ).map(&:name)).to eq(
           ['*never', '*edited', '*always']
@@ -598,7 +599,7 @@ describe Card::Query do
       expect(Card::Query.run(
         name: [:match, 'two']
       ).map(&:name).sort).to eq(
-        ['One+Two','One+Two+Three','Two'].sort
+        ['One+Two', 'One+Two+Three', 'Two']
       )
     end
   end
@@ -623,7 +624,7 @@ describe Card::Query do
         or: { name: 'Z', and: { left: 'A', right: 'C' } },
         return: :name, sort: :name
       )).to eq(
-        ['A+C','Z']
+        ['A+C', 'Z']
       )
     end
   end
@@ -689,7 +690,7 @@ describe Card::Query do
     it 'should play nicely with other properties and relationships' do
       expect(Card::Query.run(
         plus: { found_by: 'Simple Search' }, return: :name, sort: :name
-      )).to eq( Card::Query.run(
+      )).to eq(Card::Query.run(
         plus: { name: 'A' }, return: :name, sort: :name
       ))
 
@@ -703,7 +704,7 @@ describe Card::Query do
     it 'should be able to handle _self' do
       expect(Card::Query.run(
         context: 'Simple Search',
-        left: {found_by: '_self'},
+        left: { found_by: '_self' },
         right: 'B',
         return: :name
       ).first).to eq(
@@ -715,8 +716,8 @@ describe Card::Query do
 
   describe 'relative' do
     it 'should clean wql' do
-      expect( Card::Query.new(
-        part: '_self',context: 'A'
+      expect(Card::Query.new(
+        part: '_self', context: 'A'
       ).statement[:part]).to eq(
         'A'
       )


### PR DESCRIPTION
most of these changes are cleanup, but also includes fix for context problem and adds API to do this:

    Query.run(statement)

instead of having to do this:

    Query.new(statement).run

(which still works, too)