### PR TITLE
reduce unnecessary descendant processing

### DIFF
--- a/card/db/migrate_core_cards/20150708224756_add_list_cards.rb
+++ b/card/db/migrate_core_cards/20150708224756_add_list_cards.rb
@@ -4,19 +4,26 @@ class AddListCards < Card::CoreMigration
   def up
     create_card! name: 'List', codename: :list,
                  type_code: :cardtype
+
     create_card! name: 'Listed by', codename: :listed_by,
                  type_code: :cardtype
-    create_card! name: '*cached count', codename: :cached_count,
-                 subcards: {
-                    '+*right+*update'=>'[[Administrator]]',
-                    '+*right+*create'=>'[[Administrator]]',
-                    '+*right+*delete'=>'[[Administrator]]'
-                  }
-    create_card! name: '*cached content', codename: :cached_content,
-                 subcards: {
-                   '+*right+*update'=>'[[Administrator]]',
-                   '+*right+*create'=>'[[Administrator]]',
-                   '+*right+*delete'=>'[[Administrator]]'
-                 }
+
+    create_or_update name: '*cached count',
+                     codename: :cached_count,
+                     rename_if_conflict: false,
+                     subcards: {
+                        '+*right+*update'=>'[[Administrator]]',
+                        '+*right+*create'=>'[[Administrator]]',
+                        '+*right+*delete'=>'[[Administrator]]'
+                      }
+
+    create_or_update name: '*cached content',
+                     codename: :cached_content,
+                     rename_if_conflict: false,
+                     subcards: {
+                       '+*right+*update'=>'[[Administrator]]',
+                       '+*right+*create'=>'[[Administrator]]',
+                       '+*right+*delete'=>'[[Administrator]]'
+                     }
   end
 end

--- a/card/db/migrate_core_cards/20150708224756_add_list_cards.rb
+++ b/card/db/migrate_core_cards/20150708224756_add_list_cards.rb
@@ -12,18 +12,18 @@ class AddListCards < Card::CoreMigration
                      codename: :cached_count,
                      rename_if_conflict: false,
                      subcards: {
-                        '+*right+*update'=>'[[Administrator]]',
-                        '+*right+*create'=>'[[Administrator]]',
-                        '+*right+*delete'=>'[[Administrator]]'
-                      }
+                       '+*right+*update' => '[[Administrator]]',
+                       '+*right+*create' => '[[Administrator]]',
+                       '+*right+*delete' => '[[Administrator]]'
+                     }
 
     create_or_update name: '*cached content',
                      codename: :cached_content,
                      rename_if_conflict: false,
                      subcards: {
-                       '+*right+*update'=>'[[Administrator]]',
-                       '+*right+*create'=>'[[Administrator]]',
-                       '+*right+*delete'=>'[[Administrator]]'
+                       '+*right+*update' => '[[Administrator]]',
+                       '+*right+*create' => '[[Administrator]]',
+                       '+*right+*delete' => '[[Administrator]]'
                      }
   end
 end

--- a/card/lib/card/active_record_helper.rb
+++ b/card/lib/card/active_record_helper.rb
@@ -14,7 +14,7 @@ module Card::ActiveRecordHelper
   end
 
   def update_card! args
-    update_card args.merge(resolve_name_conflict: :other)
+    update_card args.merge(rename_if_conflict: :other)
   end
 
   def create_or_update name_or_args, args=nil
@@ -29,9 +29,9 @@ module Card::ActiveRecordHelper
 
   def create_or_update! name_or_args, args=nil
     if args
-      args[:resolve_name_conflict] = :other
+      args[:rename_if_conflict] = :other
     else
-      name_or_args[:resolve_name_conflict] = :other
+      name_or_args[:rename_if_conflict] = :other
     end
     create_or_update name_or_args, args
   end

--- a/card/mod/01_core/set/all/fetch.rb
+++ b/card/mod/01_core/set/all/fetch.rb
@@ -210,10 +210,9 @@ module ClassMethods
   end
 
   def write_to_local_cache card
-    if Card.cache
-      Card.cache.write_local card.key, card
-      Card.cache.write_local "~#{card.id}", card.key if card.id && card.id != 0
-    end
+    return unless Card.cache
+    Card.cache.write_local card.key, card
+    Card.cache.write_local "~#{card.id}", card.key if card.id && card.id != 0
   end
 
   def expand_mark mark, opts
@@ -242,7 +241,7 @@ module ClassMethods
     end
   end
 
-  def fullname_from_name name, new_opts = {}
+  def fullname_from_name name, new_opts={}
     if new_opts && supercard = new_opts[:supercard]
       name.to_name.to_absolute_name supercard.name
     else
@@ -253,16 +252,17 @@ end
 
 # ~~~~~~~~~~ Instance ~~~~~~~~~~~~~
 
-def fetch opts = {}
-  if traits = opts.delete(:trait)
-    traits = Array.wrap traits
-    traits.inject(self) do |card, trait|
-      Card.fetch card.cardname.trait(trait), opts
-    end
+def fetch opts={}
+  traits = opts.delete(:trait)
+  return unless traits
+  # should this fail as an incorrect api call?
+  traits = Array.wrap traits
+  traits.inject(self) do |card, trait|
+    Card.fetch card.cardname.trait(trait), opts
   end
 end
 
-def renew args = {}
+def renew args={}
   opts = args[:new].clone
   opts[:name] ||= cardname
   opts[:skip_modules] = args[:skip_modules]
@@ -275,7 +275,7 @@ def expire_pieces
   end
 end
 
-def expire subcards = false
+def expire subcards=false
   # Rails.logger.warn "expiring i:#{id}, #{inspect}"
   if subcards
     expire_subcards
@@ -286,7 +286,7 @@ def expire subcards = false
   Card.cache.delete "~#{id}" if id
 end
 
-def refresh force = false
+def refresh force=false
   if force || self.frozen? || self.readonly?
     fresh_card = self.class.find id
     fresh_card.include_set_modules
@@ -308,4 +308,3 @@ def rename_from_mark mark
   return unless mark && mark.to_s != name
   self.name = mark.to_s
 end
-

--- a/card/mod/01_core/set/all/references.rb
+++ b/card/mod/01_core/set/all/references.rb
@@ -6,7 +6,7 @@ end
 
 def extended_referencers
   # FIXME .. we really just need a number here.
-  (dependents + [self]).map(&:referencers).flatten.uniq
+  (descendants + [self]).map(&:referencers).flatten.uniq
 end
 
 

--- a/card/mod/01_core/set/all/tracked_attributes.rb
+++ b/card/mod/01_core/set/all/tracked_attributes.rb
@@ -143,12 +143,10 @@ event :expire_related, after: :store do
       Card.expire name, true
     end
   end
+end
 
-  # FIXME: really shouldn't be instantiating all the following bastards.
-  # Just need the key.
-  # fix in id_cache branch
-  dependents.each       { |c| c.expire(true) }
-  # self.referencers.each      { |c| c.expire(true) }
+event :expire_related_names, before: :expire_related, changed: :name do
+  # FIXME: look for opportunities to avoid instantiating the following
+  descendants.each { |c| c.expire(true) }
   name_referencers.each { |c| c.expire(true) }
-  # FIXME: this will need review when we do the new defaults/templating system
 end

--- a/card/mod/01_core/spec/set/all/fetch_spec.rb
+++ b/card/mod/01_core/spec/set/all/fetch_spec.rb
@@ -79,20 +79,21 @@ describe Card::Set::All::Fetch do
 
         # expires the saved card
         expect(Card.cache).to receive(:delete).with('a').and_call_original
-        expect(Card.cache).to receive(:delete).with(/~\d+/).at_least(12)
+        expect(Card.cache).to receive(:delete).with(/~\d+/).at_least(1)
         # expires plus cards
-        expect(Card.cache).to receive(:delete).with('c+a')
-        expect(Card.cache).to receive(:delete).with('d+a')
-        expect(Card.cache).to receive(:delete).with('f+a')
-        expect(Card.cache).to receive(:delete).with('a+b')
-        expect(Card.cache).to receive(:delete).with('a+c')
-        expect(Card.cache).to receive(:delete).with('a+d')
-        expect(Card.cache).to receive(:delete).with('a+e')
-        expect(Card.cache).to receive(:delete).with('a+b+c')
+        #expect(Card.cache).to receive(:delete).with('c+a')
+        #expect(Card.cache).to receive(:delete).with('d+a')
+        #expect(Card.cache).to receive(:delete).with('f+a')
+        #expect(Card.cache).to receive(:delete).with('a+b')
+        #expect(Card.cache).to receive(:delete).with('a+c')
+        #expect(Card.cache).to receive(:delete).with('a+d')
+        #expect(Card.cache).to receive(:delete).with('a+e')
+        #expect(Card.cache).to receive(:delete).with('a+b+c')
 
         # expired including? cards
-        expect(Card.cache).to receive(:delete).with('x').exactly(2).times
-        expect(Card.cache).to receive(:delete).with('y').exactly(2).times
+        #expect(Card.cache).to receive(:delete).with('x').exactly(2).times
+        #expect(Card.cache).to receive(:delete).with('y').exactly(2).times
+
         a.save!
       end
     end

--- a/card/mod/01_core/spec/set/all/tracked_attributes_spec.rb
+++ b/card/mod/01_core/spec/set/all/tracked_attributes_spec.rb
@@ -38,7 +38,7 @@ describe Card::Set::All::TrackedAttributes do
 
   describe 'set_name' do
 
-    it "should handle case variants" do
+    it 'should handle case variants' do
       @c = Card.create! name: 'chump'
       expect(@c.name).to eq('chump')
       @c.name = 'Chump'
@@ -46,7 +46,7 @@ describe Card::Set::All::TrackedAttributes do
       expect(@c.name).to eq('Chump')
     end
 
-    it "should handle changing from plus card to simple" do
+    it 'should handle changing from plus card to simple' do
       c = Card.create! name: 'four+five'
       c.name = 'nine'
       c.save!
@@ -57,41 +57,41 @@ describe Card::Set::All::TrackedAttributes do
 
     #FIXME - following tests more about fetch than set_name.  this spec still needs lots of cleanup
 
-    it "test fetch with new when present" do
-      Card.create!(name: "Carrots")
+    it 'test fetch with new when present' do
+      Card.create!(name: 'Carrots')
       cards_should_be_added 0 do
-        c=Card.fetch "Carrots", new: {}
+        c=Card.fetch 'Carrots', new: {}
         c.save
         expect(c).to be_instance_of(Card)
-        expect(Card.fetch("Carrots")).to be_instance_of(Card)
+        expect(Card.fetch('Carrots')).to be_instance_of(Card)
       end
     end
 
-    it "test_simple" do
+    it 'test_simple' do
       cards_should_be_added 1 do
         expect(Card['Boo!']).to be_nil
-        expect(Card.create(name: "Boo!")).to be_instance_of(Card)
+        expect(Card.create(name: 'Boo!')).to be_instance_of(Card)
         expect(Card['Boo!']).to be_instance_of(Card)
       end
     end
 
 
-    it "test fetch with new when not present" do
+    it 'test fetch with new when not present' do
       cards_should_be_added 1 do
-        c=Card.fetch("Tomatoes", new: {})
+        c=Card.fetch('Tomatoes', new: {})
         c.save
         expect(c).to be_instance_of(Card)
-        expect(Card.fetch("Tomatoes")).to be_instance_of(Card)
+        expect(Card.fetch('Tomatoes')).to be_instance_of(Card)
       end
     end
 
-    it "test_create_junction" do
+    it 'test_create_junction' do
       cards_should_be_added 3 do
-        expect(Card.create(name: "Peach+Pear", content: "juicy")).to be_instance_of(Card)
+        expect(Card.create(name: 'Peach+Pear', content: 'juicy')).to be_instance_of(Card)
       end
-      expect(Card["Peach"]).to be_instance_of(Card)
-      expect(Card["Pear"]).to be_instance_of(Card)
-      assert_equal "juicy", Card["Peach+Pear"].content
+      expect(Card['Peach']).to be_instance_of(Card)
+      expect(Card['Pear']).to be_instance_of(Card)
+      assert_equal 'juicy', Card['Peach+Pear'].content
     end
 
   private
@@ -106,7 +106,7 @@ describe Card::Set::All::TrackedAttributes do
 
 
 
-  describe "renaming" do
+  describe 'renaming' do
 
 
     # FIXME: these tests are TOO SLOW!  8s against server, 12s from command line.
@@ -115,107 +115,112 @@ describe Card::Set::All::TrackedAttributes do
     # Can't we just move this data to fixtures?
 
 
-    it "renaming plus card to its own child" do
-      assert_rename card("A+B"), "A+B+T"
+    it 'renaming plus card to its own child' do
+      assert_rename card('A+B'), 'A+B+T'
     end
 
-    it "clears cache for old name" do
+    it 'clears cache for old name' do
       assert_rename Card['Menu'], 'manure'
       expect(Card['Menu']).to be_nil
     end
 
-    it "wipes old references by default" do
+    it 'wipes old references by default' do
       c = Card['Menu']
       c.name = 'manure'
       c.save!
       expect(Card['manure'].references_from.size).to eq(0)
     end
 
-    it "picks up new references" do
+    it 'picks up new references' do
       Card.create name: 'kinds of poop', content: '[[manure]]'
       assert_rename Card['Menu'], 'manure'
       expect(Card['manure'].references_from.size).to eq(2)
     end
 
-    it "handles name variants" do
-      assert_rename card("B"), "b"
+    it 'handles name variants' do
+      assert_rename card('B'), 'b'
     end
 
-    it "handles plus cards renamed to simple" do
-      assert_rename card("A+B"), "K"
+    it 'handles plus cards renamed to simple' do
+      assert_rename card('A+B'), 'K'
     end
 
 
-    it "handles flipped parts" do
-      assert_rename card("A+B"), "B+A"
+    it 'handles flipped parts' do
+      assert_rename card('A+B'), 'B+A'
     end
 
-    it "test_should_error_card_exists" do
-      @t=card("T"); @t.name="A+B";
-      assert !@t.save, "save should fail"
-      assert @t.errors[:name], "should have errors on key"
+    it 'test_should_error_card_exists' do
+      @t=card('T'); @t.name='A+B';
+      assert !@t.save, 'save should fail'
+      assert @t.errors[:name], 'should have errors on key'
     end
 
-    it "test_used_as_tag" do
-      @b=card("B"); @b.name='A+D'; @b.save
+    it 'test_used_as_tag' do
+      @b=card('B'); @b.name='A+D'; @b.save
       assert @b.errors[:name]
     end
 
-    it "test_update_descendants" do
-      c1 =   Card["One"]
-      c12 =  Card["One+Two"]
-      c123 = Card["One+Two+Three"]
-      c41 =  Card["Four+One"]
-      c415 = Card["Four+One+Five"]
+    it 'test_update_descendants' do
+      card_list = [
+        Card['One+Two'],
+        Card['One+Two+Three'],
+        Card['Four+One'],
+        Card['Four+One+Five']
+      ]
 
-      assert_equal ["One+Two","One+Two+Three","Four+One","Four+One+Five"], [c12,c123,c41,c415].map(&:name)
-      c1.name="Uno"
-      c1.save!
-      assert_equal ["Uno+Two","Uno+Two+Three","Four+Uno","Four+Uno+Five"], [c12,c123,c41,c415].map(&:reload).map(&:name)
+      old_names = %w{ One+Two One+Two+Three Four+One Four+One+Five }
+      new_names = %w{ Uno+Two Uno+Two+Three Four+Uno Four+Uno+Five }
+
+      assert_equal old_names, card_list.map(&:name)
+      Card['One'].update_attributes! name: 'Uno'
+      assert_equal new_names, card_list.map(&:reload).map(&:name)
     end
 
-    it "test_should_error_invalid_name" do
-      @t=card("T"); @t.name="YT_o~Yo"; @t.save
+    it 'test_should_error_invalid_name' do
+      @t = card 'T'
+      @t.name = 'YT_o~Yo'
+      @t.save
       assert @t.errors[:name]
     end
 
-    it "test_simple_to_simple" do
-      assert_rename card("A"), "Alephant"
+    it 'test_simple_to_simple' do
+      assert_rename card('A'), 'Alephant'
     end
 
-    it "test_simple_to_junction_with_create" do
-      assert_rename card("T"), "C+J"
+    it 'test_simple_to_junction_with_create' do
+      assert_rename card('T'), 'C+J'
     end
 
-    it "test_reset_key" do
-      c = Card["Basic Card"]
-      c.name="banana card"
+    it 'test_reset_key' do
+      c = Card['Basic Card']
+      c.name='banana card'
       c.save!
       assert_equal 'banana_card', c.key
-      assert Card["Banana Card"] != nil
+      assert Card['Banana Card'] != nil
     end
 
 
 
-    it "test_rename_should_not_fail_when_updating_inaccessible_referencer" do
-      Card.create! name: "Joe Card", content: "Whattup"
+    it 'test_rename_should_not_fail_when_updating_inaccessible_referencer' do
+      Card.create! name: 'Joe Card', content: 'Whattup'
       Card::Auth.as :joe_admin do
-        Card.create! name: "Admin Card", content: "[[Joe Card]]"
+        Card.create! name: 'Admin Card', content: '[[Joe Card]]'
       end
-      c = Card["Joe Card"]
-      c.update_attributes! name: "Card of Joe", update_referencers: true
-      assert_equal "[[Card of Joe]]", Card["Admin Card"].content
+      c = Card['Joe Card']
+      c.update_attributes! name: 'Card of Joe', update_referencers: true
+      assert_equal '[[Card of Joe]]', Card['Admin Card'].content
     end
 
-    it "test_rename_should_update_structured_referencer" do
+    it 'test_rename_should_update_structured_referencer' do
       Card::Auth.as_bot do
-        c=Card.create! name: "Pit"
-        Card.create! name: "Orange", type: "Fruit", content: "[[Pit]]"
-        Card.create! name: "Fruit+*type+*structure", content: "this [[Pit]]"
+        c=Card.create! name: 'Pit'
+        Card.create! name: 'Orange', type: 'Fruit', content: '[[Pit]]'
+        Card.create! name: 'Fruit+*type+*structure', content: 'this [[Pit]]'
 
-        assert_equal "this [[Pit]]", Card["Orange"].raw_content
-        c.update_attributes! name: "Seed", update_referencers: true
-        assert_equal "this [[Seed]]", Card["Orange"].raw_content
+        assert_equal 'this [[Pit]]', Card['Orange'].raw_content
+        c.update_attributes! name: 'Seed', update_referencers: true
+        assert_equal 'this [[Seed]]', Card['Orange'].raw_content
       end
     end
 
@@ -228,88 +233,88 @@ describe Card::Set::All::TrackedAttributes do
     end
 
 
-    context "chuck" do
+    context 'chuck' do
       before do
         Card::Auth.as_bot do
-          Card.create! name: "chuck_wagn+chuck"
+          Card.create! name: 'chuck_wagn+chuck'
         end
       end
 
-      it "test_rename_name_substitution" do
-        c1, c2 = Card["chuck_wagn+chuck"], Card["chuck"]
-        assert_rename c2, "buck"
-        assert_equal "chuck_wagn+buck", Card.find(c1.id).name
+      it 'test_rename_name_substitution' do
+        c1, c2 = Card['chuck_wagn+chuck'], Card['chuck']
+        assert_rename c2, 'buck'
+        assert_equal 'chuck_wagn+buck', Card.find(c1.id).name
       end
 
-      it "test_reference_updates_plus_to_simple" do
+      it 'test_reference_updates_plus_to_simple' do
          c1 = Card::Auth.as_bot do
-           Card.create! name: 'Huck', content: "[[chuck wagn+chuck]]"
+           Card.create! name: 'Huck', content: '[[chuck wagn+chuck]]'
          end
-         c2 = Card["chuck_wagn+chuck"]
+         c2 = Card['chuck_wagn+chuck']
          assert_rename c2, 'schmuck'
          c1 = Card.find(c1.id)
          assert_equal '[[schmuck]]', c1.content
       end
     end
 
-    context "dairy" do
+    context 'dairy' do
       before do
         Card::Auth.as_bot do
-          Card.create! type: "Cardtype", name: "Dairy", content: "[[/new/{{_self|name}}|new]]"
+          Card.create! type: 'Cardtype', name: 'Dairy', content: '[[/new/{{_self|name}}|new]]'
         end
       end
 
-      it "test_renaming_card_with_self_link_should_not_hang" do
-        c = Card["Dairy"]
-        c.name = "Buttah"
+      it 'test_renaming_card_with_self_link_should_not_hang' do
+        c = Card['Dairy']
+        c.name = 'Buttah'
         c.update_referencers = true
         c.save!
-        assert_equal "[[/new/{{_self|name}}|new]]", Card["Buttah"].content
+        assert_equal '[[/new/{{_self|name}}|new]]', Card['Buttah'].content
       end
 
-      it "test_renaming_card_without_updating_references_should_not_have_errors" do
-        c = Card["Dairy"]
-        c.update_attributes "name"=>"Newt", "update_referencers"=>'false'
-        assert_equal "[[/new/{{_self|name}}|new]]", Card["Newt"].content
+      it 'test_renaming_card_without_updating_references_should_not_have_errors' do
+        c = Card['Dairy']
+        c.update_attributes 'name'=>'Newt', 'update_referencers'=>'false'
+        assert_equal '[[/new/{{_self|name}}|new]]', Card['Newt'].content
       end
     end
 
 
-    context "blues" do
+    context 'blues' do
       before do
         Card::Auth.as_bot do
-          Card.create! name: "Blue"
+          Card.create! name: 'Blue'
 
-          Card.create! name: "blue includer 1", content: "{{Blue}}"
-          Card.create! name: "blue includer 2", content: "{{blue|closed;other:stuff}}"
+          Card.create! name: 'blue includer 1', content: '{{Blue}}'
+          Card.create! name: 'blue includer 2', content: '{{blue|closed;other:stuff}}'
 
-          Card.create! name: "blue linker 1", content: "[[Blue]]"
-          Card.create! name: "blue linker 2", content: "[[blue]]"
+          Card.create! name: 'blue linker 1', content: '[[Blue]]'
+          Card.create! name: 'blue linker 2', content: '[[blue]]'
         end
       end
 
 
-      it "test_updates_inclusions_when_renaming" do
-        c1,c2,c3 = Card["Blue"], Card["blue includer 1"], Card["blue includer 2"]
-        c1.update_attributes name: "Red", update_referencers: true
-        assert_equal "{{Red}}", Card.find(c2.id).content
+      it 'test_updates_inclusions_when_renaming' do
+        c1,c2,c3 = Card['Blue'], Card['blue includer 1'], Card['blue includer 2']
+        c1.update_attributes name: 'Red', update_referencers: true
+        assert_equal '{{Red}}', Card.find(c2.id).content
         # NOTE these attrs pass through a hash stage that may not preserve order
-        assert_equal "{{Red|closed;other:stuff}}", Card.find(c3.id).content
+        assert_equal '{{Red|closed;other:stuff}}', Card.find(c3.id).content
       end
 
-      it "test_updates_inclusions_when_renaming_to_plus" do
-        c1,c2 = Card["Blue"], Card["blue includer 1"]
-        c1.update_attributes name: "blue includer 1+color", update_referencers: true
-        assert_equal "{{blue includer 1+color}}", Card.find(c2.id).content
+      it 'test_updates_inclusions_when_renaming_to_plus' do
+        c1,c2 = Card['Blue'], Card['blue includer 1']
+        c1.update_attributes name: 'blue includer 1+color', update_referencers: true
+        assert_equal '{{blue includer 1+color}}', Card.find(c2.id).content
       end
 
-      it "test_reference_updates_on_case_variants" do
-        c1,c2,c3 = Card["Blue"], Card["blue linker 1"], Card["blue linker 2"]
-        c1.reload.name = "Red"
+      it 'test_reference_updates_on_case_variants' do
+        c1,c2,c3 = Card['Blue'], Card['blue linker 1'], Card['blue linker 2']
+        c1.reload.name = 'Red'
         c1.update_referencers = true
         c1.save!
-        assert_equal "[[Red]]", Card.find(c2.id).content
-        assert_equal "[[Red]]", Card.find(c3.id).content
+        assert_equal '[[Red]]', Card.find(c2.id).content
+        assert_equal '[[Red]]', Card.find(c3.id).content
       end
     end
 

--- a/card/mod/01_core/spec/set/all/tracked_attributes_spec.rb
+++ b/card/mod/01_core/spec/set/all/tracked_attributes_spec.rb
@@ -9,7 +9,7 @@ module RenameMethods
       #revisions:   card.actions.count,
       referencers: card.referencers.map(&:name).sort,
       referees:    card.referees.map(&:name).sort,
-      dependents:  card.dependents.map(&:id).sort
+      descendants:  card.descendants.map(&:id).sort
     }
   end
 
@@ -161,7 +161,7 @@ describe Card::Set::All::TrackedAttributes do
       assert @b.errors[:name]
     end
 
-    it "test_update_dependents" do
+    it "test_update_descendants" do
       c1 =   Card["One"]
       c12 =  Card["One+Two"]
       c123 = Card["One+Two+Three"]

--- a/card/mod/03_machines/lib/card/machine.rb
+++ b/card/mod/03_machines/lib/card/machine.rb
@@ -117,7 +117,6 @@ class Card
         host_class.event(
           "reset_machine_output_#{ event_suffix }".to_sym,
           after: :expire_related, on: :save
-          #after: :store_subcards, on: :save
         ) do
           reset_machine_output!
         end

--- a/card/mod/05_standard/set/all/rich_html/editing.rb
+++ b/card/mod/05_standard/set/all/rich_html/editing.rb
@@ -98,13 +98,13 @@ format :html do
 
   view :confirm_rename do |args|
     referers = args[:referers]
-    dependents = card.dependents
+    descendants = card.descendants
     alert 'warning' do
       %{
         <h5>Are you sure you want to rename <em>#{card.name}</em>?</h5>
-        #{ %{ <h6>This change will...</h6> } if referers.any? || dependents.any? }
+        #{ %{ <h6>This change will...</h6> } if referers.any? || descendants.any? }
         <ul>
-          #{ %{<li>automatically alter #{ dependents.size } related name(s). </li>} if dependents.any? }
+          #{ %{<li>automatically alter #{ descendants.size } related name(s). </li>} if descendants.any? }
           #{ %{<li>affect at least #{referers.size} reference(s) to "#{card.name}".</li>} if referers.any? }
         </ul>
         #{ %{<p>You may choose to <em>update or ignore</em> the references.</p>} if referers.any? }

--- a/card/mod/05_standard/set/all/rich_html/editing.rb
+++ b/card/mod/05_standard/set/all/rich_html/editing.rb
@@ -2,31 +2,35 @@ format :html do
   ###---( TOP_LEVEL (used by menu) NEW / EDIT VIEWS )
 
   view :new, perms: :create, tags: :unknown_ok do |args|
-    frame_and_form :create, args, 'main-success'=>'REDIRECT' do
+    frame_and_form :create, args, 'main-success' => 'REDIRECT' do
       [
-        _optional_render( :name_formgroup,     args ),
-        _optional_render( :type_formgroup,     args ),
-        _optional_render( :content_formgroup, args ),
-        _optional_render( :button_formgroup,   args )
+        _optional_render(:name_formgroup, args),
+        _optional_render(:type_formgroup, args),
+        _optional_render(:content_formgroup, args),
+        _optional_render(:button_formgroup, args)
       ]
     end
   end
 
-
   def default_new_args args
     hidden = args[:hidden] ||= {}
     hidden[:success] ||= card.rule(:thanks) || '_self'
-    hidden[:card   ] ||={}
+    hidden[:card] ||= {}
 
     args[:optional_help] ||= :show
 
     # name field / title
-    if !params[:name_prompt] and !card.cardname.blank?
+    if !params[:name_prompt] && !card.cardname.blank?
       # name is ready and will show up in title
       hidden[:card][:name] ||= card.name
     else
       # name is not ready; need generic title
-      args[:title] ||= "New #{ card.type_name unless card.type_id == Card.default_type_id }" #fixme - overrides nest args
+      args[:title] ||= if card.type_id == Card.default_type_id
+                         'New'
+                       else
+                         "New #{card.type_name}"
+                       end
+      # FIXME: - overrides nest args
       unless card.rule_card :autoname
         # prompt for name
         hidden[:name_prompt] = true unless hidden.has_key? :name_prompt
@@ -35,39 +39,43 @@ format :html do
     end
     args[:optional_name_formgroup] ||= :hide
 
-
     # type field
-    if ( !params[:type] and !args[:type] and
-        ( main? || card.simple? || card.is_template? ) and
-        Card.new( type_id: card.type_id ).ok? :create #otherwise current type won't be on menu
-      )
+    if !params[:type] &&
+       !args[:type] &&
+       (main? || card.simple? || card.is_template?) &&
+       Card.new(type_id: card.type_id).ok?(:create)
+      # otherwise current type won't be on menu
+
       args[:optional_type_formgroup] = :show
     else
       hidden[:card][:type_id] ||= card.type_id
       args[:optional_type_formgroup] = :hide
     end
 
-
-    cancel = if main?
-      { class: 'redirecter', href: Card.path_setting('/*previous') }
-    else
-      { class: 'slotter',    href: path( view: :missing         ) }
-    end
+    cancel =
+      if main?
+        { class: 'redirecter', href: Card.path_setting('/*previous') }
+      else
+        { class: 'slotter', href: path(view: :missing) }
+      end
 
     args[:buttons] ||= %{
-      #{ button_tag 'Submit', class: 'create-submit-button', disable_with: 'Submitting', situation: 'primary' }
-      #{ button_tag 'Cancel', type: 'button', class: "create-cancel-button #{cancel[:class]}", href: cancel[:href] }
+      #{button_tag 'Submit',
+                   class: 'create-submit-button',
+                   disable_with: 'Submitting',
+                   situation: 'primary'}
+      #{button_tag 'Cancel',
+                   type: 'button',
+                   class: "create-cancel-button #{cancel[:class]}",
+                   href: cancel[:href]}
     }
-
   end
-
-
 
   view :edit, perms: :update, tags: :unknown_ok do |args|
     frame_and_form :update, args.merge(optional_toolbar: :show) do
       [
-        _optional_render( :content_formgroup, args ),
-        _optional_render( :button_formgroup,   args )
+        _optional_render(:content_formgroup, args),
+        _optional_render(:button_formgroup, args)
       ]
     end
   end

--- a/card/spec/models/card/cardtype_spec.rb
+++ b/card/spec/models/card/cardtype_spec.rb
@@ -83,47 +83,31 @@ describe Card, "created without permission" do
   end
 end
 
-
-describe Card, "Normal card with descendants" do
+describe Card, 'Normal card with descendants' do
   before do
     @a = Card['A']
   end
-  it "should confirm that it has descendants" do
+
+  it 'should confirm that it has descendants' do
     expect(@a.descendants.length).to be > 0
   end
-  it "should successfully have its type changed" do
+
+  it 'should successfully have its type changed' do
     Card::Auth.as_bot do
-      @a.type_id = Card::PhraseID;
+      @a.type_id = Card::PhraseID
       @a.save!
       expect(Card['A'].type_code).to eq(:phrase)
     end
   end
-  it "should still have its descendants after changing type" do
+  it 'should still have its descendants after changing type' do
     Card::Auth.as_bot do
       assert type_id = Card.fetch_id('cardtype_e')
-      @a.type_id = type_id; @a.save!
+      @a.type_id = type_id
+      @a.save!
       expect(Card['A'].descendants.length).to be > 0
     end
   end
 end
-
-
-=begin No extension any more, is there a modified version of this we need?
-describe Card, "Recreated Card" do
-  before do
-    Card::Auth.as_bot do
-    @ct = Card.create! name: 'Species', type: 'Cardtype'
-    @ct.delete!
-    @ct = Card.create! name: 'Species', type: 'Cardtype'
-    end
-  end
-
-  it "should have a cardtype extension" do
-    @ct.extension.should_not be_nil
-  end
-
-end
-=end
 
 describe Card, "New Cardtype" do
   before do

--- a/card/spec/models/card/cardtype_spec.rb
+++ b/card/spec/models/card/cardtype_spec.rb
@@ -84,12 +84,12 @@ describe Card, "created without permission" do
 end
 
 
-describe Card, "Normal card with dependents" do
+describe Card, "Normal card with descendants" do
   before do
     @a = Card['A']
   end
-  it "should confirm that it has dependents" do
-    expect(@a.dependents.length).to be > 0
+  it "should confirm that it has descendants" do
+    expect(@a.descendants.length).to be > 0
   end
   it "should successfully have its type changed" do
     Card::Auth.as_bot do
@@ -98,11 +98,11 @@ describe Card, "Normal card with dependents" do
       expect(Card['A'].type_code).to eq(:phrase)
     end
   end
-  it "should still have its dependents after changing type" do
+  it "should still have its descendants after changing type" do
     Card::Auth.as_bot do
       assert type_id = Card.fetch_id('cardtype_e')
       @a.type_id = type_id; @a.save!
-      expect(Card['A'].dependents.length).to be > 0
+      expect(Card['A'].descendants.length).to be > 0
     end
   end
 end


### PR DESCRIPTION
Trying to speed up a specific wikirate migration.  Issue is that there are ~145K cards ending in +cached_count, and an update to that card goes through and instantiates all of them even though they are not impacted.

It's just clearing their caches, but that should be unnecessary unless the name is changed, which it isn't.