### PR TITLE
active job fix

### DIFF
--- a/card/lib/card/set.rb
+++ b/card/lib/card/set.rb
@@ -245,6 +245,7 @@ class Card
             value = args[:symbol] ? args[:value].to_sym : args[:value]
             card.instance_variable_set("@#{attname}", value)
           end
+          card.include_set_modules
           card.send final_method
         }
       end


### PR DESCRIPTION
the :subsequent option for events didn't work for other sets than *all because set modules were not loaded in the job queue