### PR TITLE
make default nest option configurable

### DIFF
--- a/card/mod/01_core/chunk/include.rb
+++ b/card/mod/01_core/chunk/include.rb
@@ -123,7 +123,7 @@ module Card::Content::Chunk
       return if attr_string.blank?
       attr_string.strip.split(';').each do |pair|
         value, key = pair.split(':').reverse
-        key ||= DEFAULT_OPTION.to_s
+        key ||= self.class::DEFAULT_OPTION.to_s
         yield key.strip, value.strip
       end
     end

--- a/card/mod/01_core/chunk/include.rb
+++ b/card/mod/01_core/chunk/include.rb
@@ -22,6 +22,7 @@ module Card::Content::Chunk
       :variant     #
     ]
     attr_reader :options
+    DEFAULT_OPTION = :view # a value without a key is interpreted as view
 
     Card::Content::Chunk.register_class(
       self, prefix_re: '\\{\\{',
@@ -122,7 +123,7 @@ module Card::Content::Chunk
       return if attr_string.blank?
       attr_string.strip.split(';').each do |pair|
         value, key = pair.split(':').reverse
-        key ||= 'view'
+        key ||= DEFAULT_OPTION.to_s
         yield key.strip, value.strip
       end
     end


### PR DESCRIPTION
so that I can introduce formula nests in wikirate where
`{{metric | 2011}}` is interpreted as `{{metric | year: 2011}}`