### PR TITLE
chunks with same prefix

### DIFF
--- a/card/lib/card/content/chunk.rb
+++ b/card/lib/card/content/chunk.rb
@@ -9,30 +9,47 @@ class Card #::Content
     # +pattern+ that states what sort of text it matches.
     # Chunks are initalized by passing in the result of a
     # match by its pattern.
+
     module Chunk
-      mattr_accessor :raw_list, :prefix_regexp_by_list, :prefix_map
+      mattr_accessor :raw_list, :prefix_regexp_by_list,
+                     :prefix_map_by_list, :prefix_map_by_chunkname
       @@raw_list = {}
       @@prefix_regexp_by_list = {}
-      @@prefix_map = {}
+      @@prefix_map_by_chunkname = { }
+      @@prefix_map_by_list = Hash.new { |h, k| h[k] = {} }
 
       class << self
         def register_class klass, hash
           klass.config = hash.merge class: klass
           prefix_index = hash[:idx_char] || :default
           # ^ this is gross and needs to be moved out.
-          prefix_map[prefix_index] = klass.config
+
+          klassname = klass.name.split('::').last.to_sym
+          prefix_map_by_chunkname[klassname] = { prefix_index => klass.config }
+          raw_list.each do |key, list|
+            next unless list.include? klassname
+            prefix_map_by_list[key].merge! prefix_map_by_chunkname[klassname]
+          end
         end
 
         def register_list key, list
           raw_list[key] = list
+          prefix_map_by_list[key] =
+            list.each_with_object({}) do |chunkname, h|
+              next unless (p_map = prefix_map_by_chunkname[chunkname])
+              h.merge! p_map
+            end
+          prefix_map_by_list[key]
         end
 
-        def find_class_by_prefix prefix
+        def find_class_by_prefix prefix, chunk_list_key=:default
+          prefix_map = prefix_map_by_list[chunk_list_key]
           config = prefix_map[prefix[0, 1]] ||
                    prefix_map[prefix[-1, 1]] ||
                    prefix_map[:default]
           # prefix identified by first character, last character, or default.
           # a little ugly...
+
           config[:class]
         end
 

--- a/card/lib/card/content/chunk.rb
+++ b/card/lib/card/content/chunk.rb
@@ -15,7 +15,7 @@ class Card #::Content
                      :prefix_map_by_list, :prefix_map_by_chunkname
       @@raw_list = {}
       @@prefix_regexp_by_list = {}
-      @@prefix_map_by_chunkname = { }
+      @@prefix_map_by_chunkname = {}
       @@prefix_map_by_list = Hash.new { |h, k| h[k] = {} }
 
       class << self

--- a/card/lib/card/content/parser.rb
+++ b/card/lib/card/content/parser.rb
@@ -25,7 +25,7 @@ class Card
             # hold onto the non-chunk part of the string
           end
 
-          chunk_class = Chunk.find_class_by_prefix prefix
+          chunk_class = Chunk.find_class_by_prefix prefix, @chunk_list
           # get the chunk class from the prefix
           match, offset =
             chunk_class.full_match content[chunk_start..-1], prefix

--- a/card/mod/05_standard/set/all/rich_html/wrapper.rb
+++ b/card/mod/05_standard/set/all/rich_html/wrapper.rb
@@ -19,7 +19,7 @@ format :html do
 
   # Does two main things:
   # (1) gives CSS classes for styling and
-  # (2) adds card data for javascript — including the “card-slot” class,
+  # (2) adds card data for javascript — including the "card-slot" class,
   #     which in principle is not supposed to be in styles
   def wrap args={}
     @slot_view = @current_view

--- a/card/mod/05_standard/set/all/rich_html/wrapper.rb
+++ b/card/mod/05_standard/set/all/rich_html/wrapper.rb
@@ -17,6 +17,10 @@ format :html do
     JSON(options_hash)
   end
 
+  # Does two main things:
+  # (1) gives CSS classes for styling and
+  # (2) adds card data for javascript — including the “card-slot” class,
+  #     which in principle is not supposed to be in styles
   def wrap args={}
     @slot_view = @current_view
     classes = [


### PR DESCRIPTION
This is how it used to work: 
The parser fetches a list of prefixes according to the chunk list but when a prefix matches it fetches the chunk class from the complete list. So you can get a chunk that is not part of the chunk list when there is a overlap of prefixes (and that happens on wikirate where I use a special chunk class for nests in formulas)

I hacked it to avoid that problem but I think the chunk handling could get some refactoring

