### PR TITLE
fix sending extra emails to user because of renaming

### DIFF
--- a/card/mod/05_email/set/all/notify.rb
+++ b/card/mod/05_email/set/all/notify.rb
@@ -68,7 +68,7 @@ def silent_change?
 end
 
 def notable_change?
-  !silent_change? && !supercard && current_act &&
+  !silent_change? && !supercard && current_act && current_act.card_id == id &&
     Card::Auth.current_id != WagnBotID && followable?
 end
 

--- a/card/mod/05_email/set/all/notify.rb
+++ b/card/mod/05_email/set/all/notify.rb
@@ -68,8 +68,12 @@ def silent_change?
 end
 
 def notable_change?
-  !silent_change? && !supercard && current_act && current_act.card_id == id &&
+  !silent_change? && current_act_card? &&
     Card::Auth.current_id != WagnBotID && followable?
+end
+
+def current_act_card?
+  current_act && current_act.card_id == id
 end
 
 event :notify_followers_after_save, :integrate,

--- a/card/mod/05_email/spec/set/all/notify_spec.rb
+++ b/card/mod/05_email/spec/set/all/notify_spec.rb
@@ -251,6 +251,10 @@ Use this link to unfollow /update/Joe_User+*follow?card%5Bsubcards%5D%5Banother+
       Card[card_name].update_attributes! content: new_content
     end
 
+    def update_name card_name, new_name='updated content'
+      Card[card_name].update_attributes! name: new_name, update_referers: true
+    end
+
     it 'sends notifications of edits' do
       expect_user('Big Brother').to be_notified_of 'All Eyes On Me+*self'
       update 'All Eyes On Me'
@@ -265,6 +269,16 @@ Use this link to unfollow /update/Joe_User+*follow?card%5Bsubcards%5D%5Banother+
     it 'sends only one notification per user'  do
       expect_user('Big Brother').to receive(:send_change_notice).exactly(1)
       update 'Google glass'
+    end
+
+    it 'sends only one notification per user'  do
+      Card.create! name: 'WOW', content: '{{Big Brother|link}}'
+      Card::Auth.as_bot do
+        Card.create! name: 'Users+*type+John+*follow', type_id: Card::PointerID,
+                     content: "[[*always]]\n"
+      end
+      expect_user('John').to receive(:send_change_notice).exactly(1)
+      update_name 'Big Brother'
     end
 
     it 'does not send notification of not-followed cards' do


### PR DESCRIPTION
Same renaming notification emails are sent multiple times while some card contents' contain renamed card's reference.

I am not sure whether it should send one email saying name and contents of related card changed or send one email saying card name changed.
