### PR TITLE
Transaction fix

### DIFF
--- a/card/lib/card/director_register.rb
+++ b/card/lib/card/director_register.rb
@@ -1,6 +1,10 @@
 class Card
   def act opts={}
-    if !DirectorRegister.act_card
+    if DirectorRegister.act_card
+      # director.reset_stage
+      # self.only_storage_phase = true
+      main_act_block = false
+    else
       DirectorRegister.clear
       self.director = nil
       DirectorRegister.act_card = self
@@ -8,8 +12,6 @@ class Card
       if opts[:success]
         Env[:success] = Success.new(cardname, Env.params[:success])
       end
-    else
-      main_act_block = false
     end
     yield
   ensure

--- a/card/lib/card/stage_director.rb
+++ b/card/lib/card/stage_director.rb
@@ -192,7 +192,7 @@ class Card
     end
 
     def run_single_stage stage, &block
-      return unless valid_next_stage? stage
+      return true unless valid_next_stage? stage
       # puts "#{@card.name}: #{stage} stage".red
 
       @stage = stage_index stage

--- a/card/mod/010_core/set/all/actify.rb
+++ b/card/mod/010_core/set/all/actify.rb
@@ -37,27 +37,23 @@ module ClassMethods
 end
 
 def save!(*)
-  act do
-    super
-  end
+  act { super }
 end
 
 def save(*)
-  act do
-    super
-  end
+  act { super }
 end
 
-def update_attributes opts
-  act do
-    super opts
-  end
+def valid?(*)
+  act { super }
 end
 
-def update_attributes! opts
-  act do
-    super opts
-  end
+def update_attributes(*)
+  act { super }
+end
+
+def update_attributes!(*)
+  act { super }
 end
 
 def abortable


### PR DESCRIPTION
This should fix the problem of no act to wrap `valid?` that causing problems in `claim_spec.rb`'s `Card.new`.

Yesterday, we were having a problem with calling `save` in a transaction. I updated wikirate's code to add the card to `subcards` instead. That let all the test pass. I will continue working on the fix of calling `save` in a transaction. 

