### PR TITLE
fix paging with kaminari

### DIFF
--- a/card/config/initializers/02_patches/kaminari.rb
+++ b/card/config/initializers/02_patches/kaminari.rb
@@ -1,7 +1,13 @@
-module Extensions
+module Patches
   module Kaminari
     module Helpers
       module Tag
+        def self.included(klass)
+          klass.class_eval do
+            remove_method :page_url_for
+          end
+        end
+
         def page_url_for page
           p = params_for(page)
           p.delete :controller
@@ -16,8 +22,8 @@ module Extensions
           page_params = Rack::Utils.parse_nested_query "#{@param_name}=#{page}"
           page_params = @params.with_indifferent_access.deep_merge(page_params)
 
-          if Kaminari.config.respond_to?(:params_on_first_page) &&
-             !Kaminari.config.params_on_first_page && page <= 1
+          if ::Kaminari.config.respond_to?(:params_on_first_page) &&
+             !::Kaminari.config.params_on_first_page && page <= 1
             # This converts a hash:
             #   from: {other: "params", page: 1}
             #     to: {other: "params", page: nil}

--- a/card/config/initializers/extensions.rb
+++ b/card/config/initializers/extensions.rb
@@ -1,3 +1,0 @@
-class Kaminari::Helpers::Tag
-  include Extensions::Kaminari::Helpers::Tag
-end

--- a/card/config/initializers/patches.rb
+++ b/card/config/initializers/patches.rb
@@ -1,0 +1,7 @@
+module Kaminari
+  module Helpers
+    class Tag
+      include Patches::Kaminari::Helpers::Tag
+    end
+  end
+end


### PR DESCRIPTION
We have to monkey patch Kaminari::Helpers::Tag#page_url_for which doesn't work by just including a module. We have to remove the existing method.
This fixes the history bug on wikirate.