### PR TITLE
fix wrong carrierwave tmp path

### DIFF
--- a/card/mod/carrierwave/lib/carrier_wave/file_card_uploader.rb
+++ b/card/mod/carrierwave/lib/carrier_wave/file_card_uploader.rb
@@ -1,4 +1,9 @@
 module CarrierWave
+  class << self
+    def tmp_path
+      @tmp_path ||= File.expand_path("tmp", root)
+    end
+  end
   module Uploader
     # Implements a different name pattern for versions than CarrierWave's
     # default: we expect the version name at the end of the filename separated


### PR DESCRIPTION
To override the `tmp_path` in carrierwave
```
    def tmp_path
      @tmp_path ||= File.expand_path(File.join('..', 'tmp'), root)
    end
```
from `wagn/card/vendor/carrierwave/lib/carrierwave.rb`