### PR TITLE
Act.all_viewable is much faster and avoids :ghost: acts

### DIFF
--- a/card/lib/card/format/error.rb
+++ b/card/lib/card/format/error.rb
@@ -9,7 +9,7 @@ class Card
       end
 
       def debug_error e, view
-        Rails.logger.info "\nError rendering #{error_cardname} / #{view}: "\
+        Rails.logger.info "#{rendering_error e, view}:\n" \
                           "#{e.class} : #{e.message}"
         debug = Card[:debugger]
         raise e if debug && debug.content == "on"

--- a/card/mod/admin/set/self/admin.rb
+++ b/card/mod/admin/set/self/admin.rb
@@ -51,11 +51,11 @@ format :html do
     stats = [
       { title: "solid cache",
         count: solid_cache_count, unit: " cards",
-        link_text: "clear cache",
+        link_text: "clear solid cache",
         task: "clear_solid_cache" },
       { title: "machine cache",
         count: machine_cache_count, unit: " cards",
-        link_text: "clear cache",
+        link_text: "clear machine cache",
         task: "clear_machine_cache" }
     ]
     return stats unless Card.config.view_cache

--- a/card/mod/standard/set/self/recent.rb
+++ b/card/mod/standard/set/self/recent.rb
@@ -16,8 +16,8 @@ format :html do
     acts = Act.all_viewable.order(id: :desc).page(page).per(ACTS_PER_PAGE)
     acts.map do |act|
       if (act_card = act.card)
-        format = act_card.format :html
-        format.render_act args.merge(act: act, act_context: :absolute)
+        act_view_args = args.merge(act: act, act_context: :absolute)
+        act_card.format(:html).render_act act_view_args
       else
         Rails.logger.info "bad data, act: #{act}"
         ""


### PR DESCRIPTION
Many :recent pages were coming up blank (or at least many cards short), because of ghost acts.  And on wikirate the act_viewable queries were sometimes taking many seconds.

This fixes that query