### PR TITLE
polish rollback, fix broken cuke

### DIFF
--- a/card/mod/history/lib/card/act/act_renderer.rb
+++ b/card/mod/history/lib/card/act/act_renderer.rb
@@ -12,11 +12,7 @@ class Card
       end
 
       def method_missing method_name, *args, &block
-        if block_given?
-          @format.send(method_name, *args, &block)
-        else
-          @format.send(method_name, *args)
-        end
+        @format.send method_name, *args, &block
       end
 
       def respond_to_missing? method_name, _include_private=false

--- a/card/mod/history/lib/card/act/act_renderer.rb
+++ b/card/mod/history/lib/card/act/act_renderer.rb
@@ -61,9 +61,19 @@ class Card
       end
 
       def act_links
-        link_to_card(@act.card, glyphicon("time"),
-                     path: {view: :history, look_in_trash: true}) + " " +
-          link_to_card(@act.card, glyphicon("new-window"))
+        [
+          link_to_history,
+          (link_to_act_card unless @act.card.trash)
+        ].compact.join " "
+      end
+
+      def link_to_act_card
+        link_to_card @act.card, glyphicon("new-window")
+      end
+
+      def link_to_history
+        link_to_card @act.card, glyphicon("time"), path: { view: :history,
+                                                           look_in_trash: true }
       end
 
       def approved_actions
@@ -115,53 +125,64 @@ class Card
       end
 
       def accordion_expand_options
-        <<-STRING
-          data-toggle="collapse" data-parent="#accordion-#{collapse_id}" \
-          data-target=".#{collapse_id}" aria-expanded="true" \
-                   aria-controls="#{collapse_id}"
-        STRING
+        {
+          "data-toggle" => "collapse",
+          "data-parent" => "#accordion-#{collapse_id}",
+          "data-target" => ".#{collapse_id}",
+          "aria-expanded" => true,
+          "aria-controls" => collapse_id
+        }
+      end
+
+      def act_panel_options
+        { class: "panel-heading", role: "tab", id: "heading-#{collapse_id}" }
       end
 
       def act_accordion_panel
-        <<-HTML
-          <div class="panel-heading" #{accordion_expand_options} role="tab" id="heading-#{collapse_id}">
-            <h4 class="panel-title">
-               #{header}
-            </h4>
-          </div>
-          <div id="#{collapse_id}" class="panel-collapse collapse #{collapse_id}" \
-                 role="tabpanel" aria-labelledby="heading-#{collapse_id}">
-            <div class="panel-body">
-              #{details}
-            </div>
-          </div>
-        HTML
+        act_accordion_heading + act_accordion_body
+      end
+
+      def act_accordion_heading
+        wrap_with :div, act_panel_options.merge(accordion_expand_options) do
+          wrap_with :h4, header, class: "panel-title"
+        end
+      end
+
+      def act_accordion_body
+        wrap_with :div, id: collapse_id,
+                        class: "panel-collapse collapse #{collapse_id}" do
+          wrap_with :div, details, class: "panel-body"
+        end
       end
 
       def rollback_link
-        # FIXME -- doesn't this need to specify which action it wants?
-        prior =  # FIXME - should be a Card::Action method
-          actions.select { |action| action.card.last_action_id != action.id }
-        return unless card.ok?(:update) && prior.present?
-        link = link_to(
-          "Save as current", class: "slotter",
-          "data-slot-selector" => ".card-slot.history-view",
-          remote: true, method: :post, rel: "nofollow",
-          path: { action: :update, action_ids: prior,
-                  view: :open, look_in_trash: true }
-        )
-        %(<div class="act-link collapse #{collapse_id}">#{link}</div>).html_safe
+        return unless card.ok? :update
+        return unless (prior = previous_action)
+        wrap_with :div, class: "act-link collapse #{collapse_id}" do
+          link_to "Save as current",
+                  class: "slotter", remote: true,
+                  method: :post,    rel: "nofollow",
+                  "data-slot-selector" => ".card-slot.history-view",
+                  path: { action: :update, action_ids: prior,
+                          view: :open,     look_in_trash: true }
+        end
+      end
+
+      def previous_action
+        # TODO: optimize
+        actions.select { |action| action.card.last_action_id != action.id }
       end
 
       def show_or_hide_changes_link
-        link = @format.link_to_view(
-          :act, "#{@args[:hide_diff] ? 'Show' : 'Hide'} changes",
-          class: "slotter",
-          path: { act_id:      @args[:act].id,      act_seq: @args[:act_seq],
-                  hide_diff:  !@args[:hide_diff],   action_view: :expanded,
-                  act_context: @args[:act_context], look_in_trash: true }
-        )
-        %(<div class="act-link">#{link}</div>)
+        wrap_with :div, class: "act-link" do
+          @format.link_to_view(
+            :act, "#{@args[:hide_diff] ? 'Show' : 'Hide'} changes",
+            class: "slotter",
+            path: { act_id:      @args[:act].id,      act_seq: @args[:act_seq],
+                    hide_diff:  !@args[:hide_diff],   action_view: :expanded,
+                    act_context: @args[:act_context], look_in_trash: true }
+          )
+        end
       end
     end
   end

--- a/card/mod/history/set/all/history.rb
+++ b/card/mod/history/set/all/history.rb
@@ -63,9 +63,8 @@ def act_card?
   self == Card::ActManager.act_card
 end
 
-event :rollback_actions, :prepare_to_validate,
-      on: :update,
-      when: proc { |c| c.rollback_request? } do
+event :rollback_actions,
+      :prepare_to_validate, on: :update, when: :rollback_request do
   revision = { subcards: {} }
   rollback_actions = Env.params["action_ids"].map do |a_id|
     Action.fetch(a_id) || nil

--- a/wagn/features/history.feature
+++ b/wagn/features/history.feature
@@ -16,7 +16,7 @@ Feature: History
 #    And In the main card content I click "Hide changes"
 #    Then In the main card content I should not see a del with content "egg"
     When In the main card body I click "Save as current"
-    And I wait until ajax response done
+    And I wait a sec
     Then the card First should contain "chicken"
 
 

--- a/wagn/features/history.feature
+++ b/wagn/features/history.feature
@@ -16,7 +16,7 @@ Feature: History
 #    And In the main card content I click "Hide changes"
 #    Then In the main card content I should not see a del with content "egg"
     When In the main card body I click "Save as current"
-    And I wait a sec
+    And I wait 2 seconds
     Then the card First should contain "chicken"
 
 


### PR DESCRIPTION
So, the solution is lame ("wait a sec"), but at least I kinda-sort understand the problem and why the solution works.

Short version: it's a timing issue that involves cache clearing.  The reason we were seeing "chick" instead of "chicken" was that the cache hadn't expired yet. 

Basically, there's a race between the the "save as current" action and the fresh loading of the "First" page triggered by the last statement. It's possible that the caching shifted the timing dynamics because it's loading the layout faster.  (I thought at first there might be an issue with the cache clearing, but I can't explain the randomness.)