### PR TITLE
better support for edit_structure configuration

### DIFF
--- a/card/mod/core/set/all/collection.rb
+++ b/card/mod/core/set/all/collection.rb
@@ -257,6 +257,7 @@ format do
 
   def normalized_edit_fields
     edit_fields.map do |name, options|
+      options ||= name.to_s
       options = { title: options } if options.is_a?(String)
       [card.cardname.field(name), options]
     end

--- a/card/mod/core/set/all/collection.rb
+++ b/card/mod/core/set/all/collection.rb
@@ -257,7 +257,7 @@ format do
 
   def normalized_edit_fields
     edit_fields.map do |name, options|
-      options ||= name.to_s
+      options ||= Card.quick_fetch(name).name
       options = { title: options } if options.is_a?(String)
       [card.cardname.field(name), options]
     end

--- a/card/mod/standard/set/all/rich_html/form.rb
+++ b/card/mod/standard/set/all/rich_html/form.rb
@@ -6,7 +6,9 @@ format :html do
   end
 
   def multi_edit?
-    inline_nests_editor? || nests_editor? || voo.structure || card.structure
+    inline_nests_editor? || nests_editor? || # editor configured in voo
+      voo.structure || voo.edit_structure || # structure configured in voo
+      card.structure                         # structure in card rule
   end
 
   def multi_card_edit_slot


### PR DESCRIPTION
realized today that `edit_structure` is a tad confusing, since it is both the name of a view option for configuring a structure to be used in edit mode and the name of a view with which to edit structure rules.

at any rate, these changes just make it so:
A. you can use simpler arrays for voo.edit_structure, eg `voo.edit_structure = [:image]`
B. if you have an edit_structure, that will trigger the multi-edit view.