### PR TITLE
maintain name context and view after edit

### DIFF
--- a/card/lib/card/format/names.rb
+++ b/card/lib/card/format/names.rb
@@ -22,6 +22,11 @@ class Card
         context_name_list.split(",").map(&:to_name)
       end
 
+      def context_names_to_params
+        return unless @context_names
+        @context_names.join(",")
+      end
+
       def add_name_context name=nil
         name ||= card.name
         @context_names += name.to_name.part_names

--- a/card/mod/standard/set/all/rich_html/menu.rb
+++ b/card/mod/standard/set/all/rich_html/menu.rb
@@ -22,7 +22,8 @@ format :html do
   end
 
   def menu_path_opts
-    opts = { slot: { home_view: voo.home_view } }
+    opts = { slot: { home_view: (voo.home_view || @slot_view),
+                     name_context: context_names_to_params } }
     opts[:is_main] = true if main?
     opts
   end
@@ -67,7 +68,7 @@ format :html do
   end
 
   def menu_edit_link opts
-    menu_item "edit", "edit", opts.merge(view: :edit)
+    menu_item "edit", "edit", opts.merge(view: :edit, path: menu_path_opts)
   end
 
   def menu_discuss_link opts


### PR DESCRIPTION
nests always switched to open view after editing ignoring the view they had before