### PR TITLE
fixed broken comments on new cards

### DIFF
--- a/card/lib/card.rb
+++ b/card/lib/card.rb
@@ -50,8 +50,8 @@ class Card < ActiveRecord::Base
   serializable_attr_accessor(
     :action, :supercard, :superleft,
     :current_act, :current_action,
-    :comment, :comment_author,    # obviated soon
-    :update_referers,          # wrong mechanism for this
+    :comment,                     # obviated soon
+    :update_referers,             # wrong mechanism for this
     :update_all_users,            # if the above is wrong then this one too
     :silent_change,               # and this probably too
     :remove_rule_stash,

--- a/card/lib/card/cache/persistent.rb
+++ b/card/lib/card/cache/persistent.rb
@@ -105,7 +105,8 @@ class Card
       end
 
       def deep_read key
-        @store.send(:local_cache).clear
+        local_cache = @store.send :local_cache
+        local_cache.clear if local_cache
         read key
       end
 

--- a/card/mod/standard/set/all/comment.rb
+++ b/card/mod/standard/set/all/comment.rb
@@ -1,59 +1,73 @@
 event :add_comment, :prepare_to_store, on: :save, when: :comment do
-  cleaned_comment =
-    comment.split(/\n/).map do |line|
-      "<p>#{line.strip.empty? ? '&nbsp;' : line}</p>"
-    end * "\n"
+  Env.session[:comment_author] = comment_author if Env.session
+  self.content =
+    [content, card.format.comment_with_signature].compact.join "\n<hr\>\n"
+end
 
-  signature =
-    if Auth.signed_in?
-      "[[#{Auth.current.name}]]"
-    else
-      Env.session[:comment_author] = comment_author if Env.session
-      "#{comment_author} (Not signed in)"
-    end
+def comment_author
+  @comment_author ||=
+    session[:comment_author] || params[:comment_author] || "Anonymous"
+end
 
-  self.content = %(
-    #{content}
-    #{'<hr>' unless content.blank?}
-    #{cleaned_comment}
-    <div class="w-comment-author">--#{signature}.....#{Time.zone.now}</div>
-  )
+def clean_comment
+  comment.split(/\n/).map do |line|
+    "<p>#{line.strip.empty? ? '&nbsp;' : line}</p>"
+  end * "\n"
 end
 
 format do
-  view :comment_box,
-       denial: :blank, tags: :unknown_ok,
-       perms: ->(r) { r.card.ok? :comment } do |_args|
-    <<-HTML
-      <div class="comment-box nodblclick">#{comment_form}</div>
-    HTML
+  def comment_with_signature
+    card.clean_comment + "\n" + comment_signature
   end
 
-  def comment_form
-    card_form :update do
-      %(
-        #{hidden_field_tag('card[name]', card.name) if card.new_card?
-          # FIXME: wish we had more generalized solution for names.
-          # without this, nonexistent cards will often take left's linkname.
-          # (needs test)
-        }
-        #{text_area :comment, rows: 3}
-        #{comment_buttons}
-      )
+  def comment_signature
+    wrap_with :div, class: "w-comment-author" do
+      "#{comment_author}.....#{Time.zone.now}"
     end
   end
 
+  def comment_author
+    if Auth.signed_in?
+      "[[#{Auth.current.name}]]"
+    else
+      "#{card.comment_author} (Not signed in)"
+    end
+  end
+
+  view :comment_box,
+       denial: :blank, tags: :unknown_ok,
+       perms: ->(r) { r.card.ok? :comment } do
+    wrap_with :div, class: "comment-box nodblclick" do
+      card_form action: :update, no_mark: true do
+        [hidden_comment_fields, comment_box, comment_buttons]
+      end
+    end
+  end
+
+  def hidden_comment_fields
+    return unless card.new_card?
+    hidden_field_tag "card[name]", card.name
+    # FIXME: wish we had more generalized solution for names.
+    # without this, nonexistent cards will often take left's linkname.
+    # (needs test)
+  end
+
+  def comment_box
+    text_area :comment, rows: 3
+  end
+
   def comment_buttons
-    <<-HTML
-      <div class="comment-buttons">
-        #{unless Auth.signed_in?
-            card.comment_author = session[:comment_author] ||
-                                  params[:comment_author] || 'Anonymous' # ENGLISH
-            %(<label>My Name is:</label> #{text_field :comment_author})
-          end}
-        #{submit_button text: 'Comment', type: :submit,
-                        disable_with: 'Commenting'}
-      </div>
-    HTML
+    wrap_with :div, class: "comment-buttons" do
+      [comment_author_label, comment_submit_button]
+    end
+  end
+
+  def comment_author_label
+    return if Auth.signed_in?
+    %(<label>My Name is:</label> #{text_field :comment_author})
+  end
+
+  def comment_submit_button
+    submit_button text: "Comment", type: :submit, disable_with: "Commenting"
   end
 end

--- a/card/mod/standard/set/all/comment.rb
+++ b/card/mod/standard/set/all/comment.rb
@@ -6,7 +6,7 @@ end
 
 def comment_author
   @comment_author ||=
-    session[:comment_author] || params[:comment_author] || "Anonymous"
+    Env.session[:comment_author] || params[:comment_author] || "Anonymous"
 end
 
 def clean_comment

--- a/card/mod/standard/set/all/comment.rb
+++ b/card/mod/standard/set/all/comment.rb
@@ -1,12 +1,12 @@
 event :add_comment, :prepare_to_store, on: :save, when: :comment do
   Env.session[:comment_author] = comment_author if Env.session
   self.content =
-    [content, card.format.comment_with_signature].compact.join "\n<hr\>\n"
+    [content, format.comment_with_signature].compact.join "\n<hr\>\n"
 end
 
 def comment_author
   @comment_author ||=
-    Env.session[:comment_author] || params[:comment_author] || "Anonymous"
+    Env.session[:comment_author] || Env.params[:comment_author] || "Anonymous"
 end
 
 def clean_comment

--- a/card/mod/standard/set/all/rich_html/form.rb
+++ b/card/mod/standard/set/all/rich_html/form.rb
@@ -63,7 +63,7 @@ format :html do
 
   def card_form action, opts={}
     @form_root = true
-    url, action = card_form_url action
+    url, action = card_form_url_and_action action
     html_opts = card_form_html_opts action, opts
     form_for card, url: url, html: html_opts, remote: true do |form|
       @form = form
@@ -88,7 +88,7 @@ format :html do
     opts
   end
 
-  def card_form_url action
+  def card_form_url_and_action action
     case action
     when Symbol then [path(action: action), action]
     when Hash   then [path(action), action[:action]]


### PR DESCRIPTION
Tricky one.

Issue was that form wasn't working when <form> tag had an "action" attribute with a query in it (eg `/update?card[name]=blah` as opposed to just `update`). 

Not sure exactly where that causes problems, but my guess is that a query signals to the rails remote handling that it should do a GET (and ignore the form elements, like the comment box).

I need to record this somewhere before merging.